### PR TITLE
google_project: add realm variable OPST-84

### DIFF
--- a/google_project/README.md
+++ b/google_project/README.md
@@ -43,6 +43,7 @@ No modules.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Override default project id. Only use if the project id is already taken. | `string` | `""` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of project e.g., autopush | `string` | n/a | yes |
 | <a name="input_project_services"></a> [project\_services](#input\_project\_services) | List of google\_project\_service APIs to enable. | `list(string)` | `[]` | no |
+| <a name="input_realm"></a> [realm](#input\_realm) | Realm is a grouping of environments being one of: global, nonprod, prod | `string` | `""` | no |
 
 ## Outputs
 

--- a/google_project/locals.tf
+++ b/google_project/locals.tf
@@ -14,6 +14,7 @@ locals {
     cost_center    = var.cost_center
     program_code   = var.program_code
     program_name   = var.program_name
+    realm          = var.realm
   }
   all_project_labels = merge(local.default_project_labels, var.extra_project_labels)
 

--- a/google_project/variables.tf
+++ b/google_project/variables.tf
@@ -79,3 +79,14 @@ variable "project_services" {
   default     = []
   type        = list(string)
 }
+
+variable "realm" {
+  description = "Realm is a grouping of environments being one of: global, nonprod, prod"
+  default     = ""
+  type        = string
+
+  validation {
+    condition     = contains(["global", "nonprod", "prod"], var.realm)
+    error_message = "Valid values for realm: global, nonprod, prod."
+  }
+}


### PR DESCRIPTION
As part of the discussion https://github.com/mozilla/terraform-modules/pull/2#discussion_r755407063, I didn't clearly specify that we needed to keep the realm label. 

I believe only https://github.com/mozilla-it/global-platform-admin/blob/ac672e3eef0fd51054ddb991f1bab6f47d89b51e/shared/tf/projects.tf#L22-L32 is referring to this now and I will submit a PR for the change.

r? 