### PR TITLE
with realm variable added, update local.project_name

### DIFF
--- a/google_project/locals.tf
+++ b/google_project/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  project_name         = var.project_name
+  project_name         = "${var.project_name}-${var.realm}"
   display_name         = coalesce(var.display_name, local.project_name)
   project_generated_id = "${format("%.25s", "moz-fx-${local.project_name}")}-${random_id.project.hex}"
   project_id           = coalesce(var.project_id, local.project_generated_id)


### PR DESCRIPTION
Jira: Came up in context of https://mozilla-hub.atlassian.net/browse/OPST-333

What this PR does:
* @jasonthomas added back in realm variable to this module in a previous PR (#6 ) 
* with that added back in, need to add the interpolation for the default project_name to be project_name plus realm
* still leaving out env_code and environment variables, since seems to only be used as labels to replicate value of realm