### PR TITLE
google_project: include project_number in outputs

### DIFF
--- a/google_project/README.md
+++ b/google_project/README.md
@@ -51,3 +51,4 @@ No modules.
 |------|-------------|
 | <a name="output_name"></a> [name](#output\_name) | n/a |
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | n/a |
+| <a name="output_project_number"></a> [project\_number](#output\_project\_number) | n/a |

--- a/google_project/outputs.tf
+++ b/google_project/outputs.tf
@@ -2,6 +2,10 @@ output "project_id" {
   value = google_project.project.project_id
 }
 
+output "project_number" {
+  value = google_project.project.number
+}
+
 output "name" {
   value = google_project.project.name
 }


### PR DESCRIPTION
project number is useful in the context of provisioning shared vpc subnet resources and IAM permissions. 

r?