### PR TITLE
add cloudbilling to default GCP project enabled services

### DIFF
--- a/google_project/locals.tf
+++ b/google_project/locals.tf
@@ -18,6 +18,16 @@ locals {
   }
   all_project_labels = merge(local.default_project_labels, var.extra_project_labels)
 
-  default_project_services = ["compute.googleapis.com", "container.googleapis.com", "dns.googleapis.com", "logging.googleapis.com", "monitoring.googleapis.com", "servicenetworking.googleapis.com", "stackdriver.googleapis.com", "iamcredentials.googleapis.com"]
-  all_project_services     = setunion(local.default_project_services, var.project_services)
+  default_project_services = [
+    "cloudbilling.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "dns.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "stackdriver.googleapis.com"
+  ]
+  all_project_services = setunion(local.default_project_services, var.project_services)
 }


### PR DESCRIPTION
Jira: came up in context of https://github.com/mozilla-it/global-platform-admin/pull/63

What this PR does:
* adds cloudbilling.googleapis.com to default APIs to be enabled on any GCP project
* enabling this API allows us to associate the billing account ID to the project