### PR TITLE
Add Google Artifact Registry module.

### DIFF
--- a/google_gar/README.md
+++ b/google_gar/README.md
@@ -1,0 +1,52 @@
+# Terraform Module: Google Artifact Registry repository
+Creates a GAR repository and a service account to access it.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_artifact_registry_repository.repository](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_artifact_registry_repository) | resource |
+| [google-beta_google_artifact_registry_repository_iam_member.reader](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_artifact_registry_repository_iam_member) | resource |
+| [google-beta_google_artifact_registry_repository_iam_member.writer](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_artifact_registry_repository_iam_member) | resource |
+| [google_project_service.gar](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_account.writer_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_application"></a> [application](#input\_application) | Application, e.g. bouncer. | `string` | n/a | yes |
+| <a name="input_realm"></a> [realm](#input\_realm) | Realm, e.g. nonprod. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | n/a | `string` | `null` | no |
+| <a name="input_format"></a> [format](#input\_format) | n/a | `string` | `"DOCKER"` | no |
+| <a name="input_location"></a> [location](#input\_location) | Location of the repository. Should generally be set to a multi-region location like 'us' or 'europe'. | `string` | `"us"` | no |
+| <a name="input_project"></a> [project](#input\_project) | n/a | `string` | `null` | no |
+| <a name="input_repository_id"></a> [repository\_id](#input\_repository\_id) | n/a | `string` | `null` | no |
+| <a name="input_repository_readers"></a> [repository\_readers](#input\_repository\_readers) | List of principals that should be granted read access to the respository. | `list(string)` | `[]` | no |
+| <a name="input_writer_service_account_id"></a> [writer\_service\_account\_id](#input\_writer\_service\_account\_id) | n/a | `string` | `"artifact-writer"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_repository"></a> [repository](#output\_repository) | n/a |
+| <a name="output_writer_service_account"></a> [writer\_service\_account](#output\_writer\_service\_account) | n/a |

--- a/google_gar/examples/README.md
+++ b/google_gar/examples/README.md
@@ -1,0 +1,1 @@
+# Example usage of the google_gar module

--- a/google_gar/examples/example.tf
+++ b/google_gar/examples/example.tf
@@ -1,0 +1,8 @@
+module "gar" {
+  source = "github.com/mozilla/terraform-modules//google_gar?ref=main"
+
+  description        = "Default repository for test project"
+  application        = "glonk"
+  realm              = "nonprod"
+  repository_readers = ["user:jdoe@firefox.gcp.mozilla.com"]
+}

--- a/google_gar/main.tf
+++ b/google_gar/main.tf
@@ -1,0 +1,51 @@
+/**
+ * # Terraform Module: Google Artifact Registry repository
+ * Creates a GAR repository and a service account to access it.
+ */
+
+
+resource "google_project_service" "gar" {
+  project            = var.project
+  disable_on_destroy = "false"
+  service            = "artifactregistry.googleapis.com"
+}
+
+resource "google_artifact_registry_repository" "repository" {
+  provider      = google-beta
+  depends_on    = [google_project_service.gar]
+  repository_id = coalesce(var.repository_id, "${var.application}-${var.realm}")
+  format        = var.format
+  location      = var.location
+  description   = var.description
+  project       = var.project
+
+  labels = {
+    app   = var.application
+    realm = var.realm
+  }
+}
+
+resource "google_artifact_registry_repository_iam_member" "reader" {
+  provider   = google-beta
+  for_each   = toset(var.repository_readers)
+  project    = var.project
+  location   = var.location
+  repository = google_artifact_registry_repository.repository.name
+  role       = "roles/artifactregistry.reader"
+  member     = each.key
+}
+
+resource "google_service_account" "writer_service_account" {
+  account_id   = var.writer_service_account_id
+  display_name = "Artifact Writer"
+  project      = var.project
+}
+
+resource "google_artifact_registry_repository_iam_member" "writer" {
+  provider   = google-beta
+  project    = var.project
+  location   = var.location
+  repository = google_artifact_registry_repository.repository.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.writer_service_account.email}"
+}

--- a/google_gar/outputs.tf
+++ b/google_gar/outputs.tf
@@ -1,0 +1,7 @@
+output "repository" {
+  value = google_artifact_registry_repository.repository
+}
+
+output "writer_service_account" {
+  value = google_service_account.writer_service_account
+}

--- a/google_gar/variables.tf
+++ b/google_gar/variables.tf
@@ -1,0 +1,46 @@
+variable "repository_id" {
+  type    = string
+  default = null
+}
+
+variable "format" {
+  type    = string
+  default = "DOCKER"
+}
+
+variable "location" {
+  type        = string
+  default     = "us"
+  description = "Location of the repository. Should generally be set to a multi-region location like 'us' or 'europe'."
+}
+
+variable "description" {
+  type    = string
+  default = null
+}
+
+variable "application" {
+  type        = string
+  description = "Application, e.g. bouncer."
+}
+
+variable "realm" {
+  description = "Realm, e.g. nonprod."
+  type        = string
+}
+
+variable "project" {
+  type    = string
+  default = null
+}
+
+variable "repository_readers" {
+  type        = list(string)
+  default     = []
+  description = "List of principals that should be granted read access to the respository."
+}
+
+variable "writer_service_account_id" {
+  type    = string
+  default = "artifact-writer"
+}

--- a/google_gar/versions.tf
+++ b/google_gar/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.0"
+    }
+  }
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
I tested this with a newly created project. It took a while for the relevant API to get enabled, and I had to add an explicit dependency for that to work correctly, but now I believe everything is working as intended.

I did not add an environment label, since we don't plan to have more than one registry per project. As discussed in the last meeting between Jason and me, we may even only want a single repository per app, so maybe we want to remove the realm label as well.

https://mozilla-hub.atlassian.net/browse/OPST-378