### PR TITLE
changing iam_binding to iam_member

### DIFF
--- a/google_gke_tenant/gke_service_account.tf
+++ b/google_gke_tenant/gke_service_account.tf
@@ -4,12 +4,10 @@ resource "google_service_account" "gke-account" {
   project     = var.project_id
 }
 
-resource "google_service_account_iam_binding" "workload-identity-for-gke" {
+resource "google_service_account_iam_member" "workload-identity-for-gke" {
   service_account_id = google_service_account.gke-account.name
   role               = "roles/iam.workloadIdentityUser"
-  members = [
-    "serviceAccount:${var.cluster_project_id}.svc.id.goog[${var.application}-${var.environment}/external-secrets]"
-  ]
+  member             = "serviceAccount:${var.cluster_project_id}.svc.id.goog[${var.application}-${var.environment}/external-secrets]"
 }
 
 # permissions for use with External Secrets Operator in GKE


### PR DESCRIPTION
Looks like using `..._iam_binding` clashes with tenant bindings if they want to use workload identity, so they should both use `...iam_member`