### PR TITLE
aws_gcp_vpn: Add variable for custom route advertisements

### DIFF
--- a/aws_gcp_vpn/README.md
+++ b/aws_gcp_vpn/README.md
@@ -20,3 +20,7 @@ resource "aws_vpn_gateway" "default" {
 ```
 
 You'll also need to turn on Route Propagation in the routing table for this VPC
+
+## Exporting peer VPN network routes to AWS
+
+If you'd like to connect to a service using VPC networking peering, such as CloudSQL, [follow the steps](https://cloud.google.com/sql/docs/mysql/configure-private-ip#vpn) to export custom routes and then create a custom route advertisement for that range.

--- a/aws_gcp_vpn/main.tf
+++ b/aws_gcp_vpn/main.tf
@@ -55,6 +55,18 @@ resource "google_compute_router" "default" {
 
   bgp {
     asn = var.gcp_private_asn
+
+    advertise_mode    = length(var.gcp_advertised_ip_ranges) > 0 ? "CUSTOM" : "DEFAULT"
+    advertised_groups = length(var.gcp_advertised_ip_ranges) > 0 ? ["ALL_SUBNETS"] : []
+
+    dynamic "advertised_ip_ranges" {
+      for_each = var.gcp_advertised_ip_ranges
+
+      content {
+        description = advertised_ip_ranges.value.description
+        range       = advertised_ip_ranges.value.range
+      }
+    }
   }
 }
 

--- a/aws_gcp_vpn/variables.tf
+++ b/aws_gcp_vpn/variables.tf
@@ -18,6 +18,12 @@ variable "aws_vpn_gateway_id" {
   type        = string
 }
 
+variable "gcp_advertised_ip_ranges" {
+  default     = []
+  description = "value"
+  type        = set(object({description = string, range = string}))
+}
+
 variable "gcp_network_name" {
   default     = "default"
   description = "GCP VPN network name"

--- a/aws_gcp_vpn/variables.tf
+++ b/aws_gcp_vpn/variables.tf
@@ -21,7 +21,7 @@ variable "aws_vpn_gateway_id" {
 variable "gcp_advertised_ip_ranges" {
   default     = []
   description = "value"
-  type        = set(object({description = string, range = string}))
+  type        = set(object({ description = string, range = string }))
 }
 
 variable "gcp_network_name" {


### PR DESCRIPTION
This is required to allow connecting to GCP services using peer vpc networks such as CloudSQL