### PR TITLE
feat: copy google-cdn-external from cloudops-infra-terraform-modules

### DIFF
--- a/google_cdn-external/README.md
+++ b/google_cdn-external/README.md
@@ -1,0 +1,56 @@
+# Google CDN Distribution for external endpoints
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.0, < 5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.0, < 5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_backend_service.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
+| [google_compute_global_forwarding_rule.http](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_forwarding_rule.https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_network_endpoint.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_network_endpoint) | resource |
+| [google_compute_global_network_endpoint_group.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_network_endpoint_group) | resource |
+| [google_compute_target_http_proxy.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_http_proxy) | resource |
+| [google_compute_target_https_proxy.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_https_proxy) | resource |
+| [google_compute_url_map.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |
+| [google_compute_url_map.https_redirect](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addresses"></a> [addresses](#input\_addresses) | IP Addresses. | <pre>object({<br>    ipv4 = string,<br>    ipv6 = string,<br>  })</pre> | n/a | yes |
+| <a name="input_application"></a> [application](#input\_application) | Application name. | `string` | n/a | yes |
+| <a name="input_certs"></a> [certs](#input\_certs) | List of certificates ids. If this list is empty, this will be HTTP only. | `list(string)` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of distribution. | `string` | n/a | yes |
+| <a name="input_origin_fqdn"></a> [origin\_fqdn](#input\_origin\_fqdn) | Origin's fqdn: e.g., 'mozilla.org'. | `string` | n/a | yes |
+| <a name="input_primary_hostname"></a> [primary\_hostname](#input\_primary\_hostname) | Primary hostname of service. | `string` | n/a | yes |
+| <a name="input_realm"></a> [realm](#input\_realm) | Realm name. | `string` | n/a | yes |
+| <a name="input_backend_timeout_sec"></a> [backend\_timeout\_sec](#input\_backend\_timeout\_sec) | Timeout for backend service. | `number` | `10` | no |
+| <a name="input_cdn_policy"></a> [cdn\_policy](#input\_cdn\_policy) | CDN policy config to be passed to backend service. | `map(any)` | `{}` | no |
+| <a name="input_https_redirect"></a> [https\_redirect](#input\_https\_redirect) | Redirect from http to https. | `bool` | `true` | no |
+| <a name="input_log_sample_rate"></a> [log\_sample\_rate](#input\_log\_sample\_rate) | Sample rate for Cloud Logging. Must be in the interval [0, 1]. | `number` | `1` | no |
+| <a name="input_origin_port"></a> [origin\_port](#input\_origin\_port) | Port to use for origin. | `number` | `443` | no |
+| <a name="input_origin_protocol"></a> [origin\_protocol](#input\_origin\_protocol) | Protocol for the origin. | `string` | `"HTTPS"` | no |
+| <a name="input_path_rewrites"></a> [path\_rewrites](#input\_path\_rewrites) | Dictionary of path matchers. | <pre>map(object({<br>    hosts  = list(string)<br>    paths  = list(string)<br>    target = string<br>  }))</pre> | `{}` | no |
+
+## Outputs
+
+No outputs.

--- a/google_cdn-external/main.tf
+++ b/google_cdn-external/main.tf
@@ -1,0 +1,149 @@
+/**
+ * # Google CDN Distribution for external endpoints
+ */
+
+locals {
+  name_prefix = "${var.application}-${var.environment}-${var.name}-cdn"
+}
+
+resource "google_compute_global_network_endpoint_group" "default" {
+  name                  = local.name_prefix
+  default_port          = var.origin_port
+  network_endpoint_type = "INTERNET_FQDN_PORT"
+}
+
+resource "google_compute_global_network_endpoint" "default" {
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.default.name
+
+  fqdn = var.origin_fqdn
+  port = var.origin_port
+}
+
+resource "google_compute_backend_service" "default" {
+  name                            = local.name_prefix
+  enable_cdn                      = true
+  timeout_sec                     = var.backend_timeout_sec
+  connection_draining_timeout_sec = 10
+
+  protocol = var.origin_protocol
+
+  custom_request_headers = [
+    "host: ${var.origin_fqdn}"
+  ]
+
+  backend {
+    group = google_compute_global_network_endpoint_group.default.self_link
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = var.log_sample_rate
+  }
+
+  dynamic "cdn_policy" {
+    for_each = var.cdn_policy != {} ? [1] : []
+
+    content {
+      cache_mode                   = lookup(var.cdn_policy, "cache_mode", null)
+      client_ttl                   = lookup(var.cdn_policy, "client_ttl", null)
+      default_ttl                  = lookup(var.cdn_policy, "default_ttl", null)
+      max_ttl                      = lookup(var.cdn_policy, "max_ttl", null)
+      serve_while_stale            = lookup(var.cdn_policy, "serve_while_stale", null)
+      signed_url_cache_max_age_sec = lookup(var.cdn_policy, "signed_url_cache_max_age_sec", null)
+      cache_key_policy {
+        include_host         = true
+        include_protocol     = true
+        include_query_string = true
+      }
+    }
+  }
+
+  depends_on = [google_compute_global_network_endpoint.default]
+}
+
+resource "google_compute_url_map" "default" {
+  name = local.name_prefix
+
+  default_service = google_compute_backend_service.default.id
+
+  dynamic "host_rule" {
+    for_each = var.path_rewrites
+    content {
+      hosts        = host_rule.value.hosts
+      path_matcher = host_rule.key
+    }
+  }
+
+  dynamic "path_matcher" {
+    for_each = var.path_rewrites
+    content {
+      name            = path_matcher.key
+      default_service = google_compute_backend_service.default.self_link
+      path_rule {
+        paths   = path_matcher.value.paths
+        service = google_compute_backend_service.default.self_link
+        route_action {
+          url_rewrite {
+            path_prefix_rewrite = path_matcher.value.target
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "google_compute_url_map" "https_redirect" {
+  name = "${local.name_prefix}-redirect"
+
+  default_url_redirect {
+    host_redirect          = var.primary_hostname
+    https_redirect         = true
+    strip_query            = false
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+  }
+}
+
+resource "google_compute_target_http_proxy" "default" {
+  name    = local.name_prefix
+  url_map = var.https_redirect ? google_compute_url_map.https_redirect.id : google_compute_url_map.default.id
+}
+
+resource "google_compute_target_https_proxy" "default" {
+  name             = local.name_prefix
+  url_map          = google_compute_url_map.default.id
+  ssl_certificates = var.certs
+}
+
+resource "google_compute_global_forwarding_rule" "http" {
+  for_each = {
+    ipv4 = {
+      address = var.addresses.ipv4
+    },
+    ipv6 = {
+      address = var.addresses.ipv6
+    },
+  }
+
+  name       = "${local.name_prefix}-http-${each.key}"
+  target     = google_compute_target_http_proxy.default.id
+  port_range = "80"
+
+  ip_address = each.value.address
+}
+
+resource "google_compute_global_forwarding_rule" "https" {
+  for_each = {
+    ipv4 = {
+      address = var.addresses.ipv4
+    },
+    ipv6 = {
+      address = var.addresses.ipv6
+    },
+  }
+
+  name       = "${local.name_prefix}-https-${each.key}"
+  target     = google_compute_target_https_proxy.default.id
+  port_range = "443"
+
+  ip_address = each.value.address
+}

--- a/google_cdn-external/variables.tf
+++ b/google_cdn-external/variables.tf
@@ -1,0 +1,88 @@
+variable "application" {
+  type        = string
+  description = "Application name."
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name."
+}
+
+variable "realm" {
+  type        = string
+  description = "Realm name."
+}
+
+variable "name" {
+  type        = string
+  description = "Name of distribution."
+}
+
+variable "origin_fqdn" {
+  type        = string
+  description = "Origin's fqdn: e.g., 'mozilla.org'."
+}
+
+variable "origin_port" {
+  type        = number
+  default     = 443
+  description = "Port to use for origin."
+}
+
+variable "origin_protocol" {
+  type        = string
+  default     = "HTTPS"
+  description = "Protocol for the origin."
+}
+
+variable "primary_hostname" {
+  type        = string
+  description = "Primary hostname of service."
+}
+
+variable "certs" {
+  type        = list(string)
+  description = "List of certificates ids. If this list is empty, this will be HTTP only."
+}
+
+variable "https_redirect" {
+  type        = bool
+  default     = true
+  description = "Redirect from http to https."
+}
+
+variable "addresses" {
+  type = object({
+    ipv4 = string,
+    ipv6 = string,
+  })
+  description = "IP Addresses."
+}
+
+variable "path_rewrites" {
+  description = "Dictionary of path matchers."
+  type = map(object({
+    hosts  = list(string)
+    paths  = list(string)
+    target = string
+  }))
+  default = {}
+}
+
+variable "cdn_policy" {
+  description = "CDN policy config to be passed to backend service."
+  type        = map(any)
+  default     = {}
+}
+
+variable "log_sample_rate" {
+  description = "Sample rate for Cloud Logging. Must be in the interval [0, 1]."
+  type        = number
+  default     = 1.0
+}
+
+variable "backend_timeout_sec" {
+  type        = number
+  default     = 10
+  description = "Timeout for backend service."
+}

--- a/google_cdn-external/versions.tf
+++ b/google_cdn-external/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.0, < 5"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
# Description
This PR copies `google-cdn-external` from [cloudops-infra-terraform-modules](https://github.com/mozilla-services/cloudops-infra-terraform-modules). It will be used in [webservices-infra/data-static-websites](https://github.com/mozilla-it/webservices-infra/tree/main/data-static-websites)

I was thinking about linking this modules as a git submodule in [cloudops-infra-terraform-modules](https://github.com/mozilla-it/webservices-infra/tree/main/data-static-websites) so we don't have to maintain both modules. Looking for feedback on this