### PR TITLE
feat(cdn-external): make var.name optional and remove unused var.realm

### DIFF
--- a/google_cdn-external/README.md
+++ b/google_cdn-external/README.md
@@ -37,19 +37,18 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_addresses"></a> [addresses](#input\_addresses) | IP Addresses. | <pre>object({<br>    ipv4 = string,<br>    ipv6 = string,<br>  })</pre> | n/a | yes |
 | <a name="input_application"></a> [application](#input\_application) | Application name. | `string` | n/a | yes |
-| <a name="input_certs"></a> [certs](#input\_certs) | List of certificates ids. If this list is empty, this will be HTTP only. | `list(string)` | n/a | yes |
-| <a name="input_environment"></a> [environment](#input\_environment) | Environment name. | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Name of distribution. | `string` | n/a | yes |
-| <a name="input_origin_fqdn"></a> [origin\_fqdn](#input\_origin\_fqdn) | Origin's fqdn: e.g., 'mozilla.org'. | `string` | n/a | yes |
-| <a name="input_primary_hostname"></a> [primary\_hostname](#input\_primary\_hostname) | Primary hostname of service. | `string` | n/a | yes |
-| <a name="input_realm"></a> [realm](#input\_realm) | Realm name. | `string` | n/a | yes |
 | <a name="input_backend_timeout_sec"></a> [backend\_timeout\_sec](#input\_backend\_timeout\_sec) | Timeout for backend service. | `number` | `10` | no |
 | <a name="input_cdn_policy"></a> [cdn\_policy](#input\_cdn\_policy) | CDN policy config to be passed to backend service. | `map(any)` | `{}` | no |
+| <a name="input_certs"></a> [certs](#input\_certs) | List of certificates ids. If this list is empty, this will be HTTP only. | `list(string)` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name. | `string` | n/a | yes |
 | <a name="input_https_redirect"></a> [https\_redirect](#input\_https\_redirect) | Redirect from http to https. | `bool` | `true` | no |
 | <a name="input_log_sample_rate"></a> [log\_sample\_rate](#input\_log\_sample\_rate) | Sample rate for Cloud Logging. Must be in the interval [0, 1]. | `number` | `1` | no |
+| <a name="input_name"></a> [name](#input\_name) | Optional name of distribution. | `string` | `""` | no |
+| <a name="input_origin_fqdn"></a> [origin\_fqdn](#input\_origin\_fqdn) | Origin's fqdn: e.g., 'mozilla.org'. | `string` | n/a | yes |
 | <a name="input_origin_port"></a> [origin\_port](#input\_origin\_port) | Port to use for origin. | `number` | `443` | no |
 | <a name="input_origin_protocol"></a> [origin\_protocol](#input\_origin\_protocol) | Protocol for the origin. | `string` | `"HTTPS"` | no |
 | <a name="input_path_rewrites"></a> [path\_rewrites](#input\_path\_rewrites) | Dictionary of path matchers. | <pre>map(object({<br>    hosts  = list(string)<br>    paths  = list(string)<br>    target = string<br>  }))</pre> | `{}` | no |
+| <a name="input_primary_hostname"></a> [primary\_hostname](#input\_primary\_hostname) | Primary hostname of service. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/google_cdn-external/main.tf
+++ b/google_cdn-external/main.tf
@@ -3,7 +3,7 @@
  */
 
 locals {
-  name_prefix = "${var.application}-${var.environment}-${var.name}-cdn"
+  name_prefix = join("-", [var.application, var.environment, var.name != "" ? "${var.name}-cdn" : "cdn"])
 }
 
 resource "google_compute_global_network_endpoint_group" "default" {

--- a/google_cdn-external/variables.tf
+++ b/google_cdn-external/variables.tf
@@ -8,14 +8,10 @@ variable "environment" {
   description = "Environment name."
 }
 
-variable "realm" {
-  type        = string
-  description = "Realm name."
-}
-
 variable "name" {
   type        = string
-  description = "Name of distribution."
+  description = "Optional name of distribution."
+  default     = ""
 }
 
 variable "origin_fqdn" {


### PR DESCRIPTION
# Description
This PR makes `var.name` optional and removes `var.realm` since it's unused.

Once this is merged, related PR needs to be updated to point at `main` instead of a specific commit SHA.

# Related PR
https://github.com/mozilla-it/webservices-infra/pull/141