### PR TITLE
Added separate config for replica instances

### DIFF
--- a/google_cloudsql_mysql/README.md
+++ b/google_cloudsql_mysql/README.md
@@ -135,6 +135,9 @@ output "mysql_database" {
 | <a name="input_realm"></a> [realm](#input\_realm) | Realm e.g., nonprod. | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `string` | `"us-west1"` | no |
 | <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of replicas to create | `number` | `0` | no |
+| <a name="input_replica_db_cpu"></a> [replica\_db\_cpu](#input\_replica\_db\_cpu) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"2"` | no |
+| <a name="input_replica_db_mem_gb"></a> [replica\_db\_mem\_gb](#input\_replica\_db\_mem\_gb) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"12"` | no |
+| <a name="input_replica_tier_override"></a> [replica\_tier\_override](#input\_replica\_tier\_override) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica\_db\_cpu and var.replica\_db\_mem\_gb | `string` | `""` | no |
 | <a name="input_tier_override"></a> [tier\_override](#input\_tier\_override) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.db\_cpu and var.db\_mem\_gb | `string` | `""` | no |
 
 ## Outputs

--- a/google_cloudsql_mysql/main.tf
+++ b/google_cloudsql_mysql/main.tf
@@ -7,6 +7,7 @@ locals {
   default_database_name = "${var.application}-${var.realm}-${var.environment}-${var.instance_version}"
   database_name         = coalesce(var.custom_database_name, local.default_database_name)
   tier                  = coalesce(var.tier_override, "db-custom-${var.db_cpu}-${var.db_mem_gb * 1024}")
+  replica_tier          = coalesce(var.replica_tier_override, "db-custom-${var.replica_db_cpu}-${var.replica_db_mem_gb * 1024}")
 
   default_replica_name = "${local.database_name}-replica"
   replica_name         = coalesce(var.custom_replica_name, local.default_replica_name)
@@ -93,7 +94,10 @@ resource "google_sql_database_instance" "replica" {
   }
 
   settings {
-    tier = local.tier
+    tier = local.replica_tier
+
+    availability_type = var.availability_type
+
     dynamic "database_flags" {
       for_each = var.database_flags
       content {

--- a/google_cloudsql_mysql/variables.tf
+++ b/google_cloudsql_mysql/variables.tf
@@ -58,8 +58,23 @@ variable "db_mem_gb" {
   default     = "12"
 }
 
+variable "replica_db_cpu" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  default     = "2"
+}
+
+variable "replica_db_mem_gb" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  default     = "12"
+}
+
 variable "tier_override" {
   description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.db_cpu and var.db_mem_gb"
+  default     = ""
+}
+
+variable "replica_tier_override" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica_db_cpu and var.replica_db_mem_gb"
   default     = ""
 }
 


### PR DESCRIPTION
A few of the services we run have more load on the replica instances and require different instance types for their replicas. 

* added separate config for replica cpu/memory 
* set replica `availability_type` to match primary instance 