### PR TITLE
feat(google_gke): add monitoring_enable_managed_prometheus flag

### DIFF
--- a/google_gke/cluster.tf
+++ b/google_gke/cluster.tf
@@ -83,8 +83,16 @@ resource "google_container_cluster" "primary" {
       "WORKLOADS"
     ]
   }
+
   monitoring_config {
     enable_components = var.monitoring_config_enable_components
+    dynamic "managed_prometheus" {
+      for_each = var.monitoring_enable_managed_prometheus ? [1] : []
+
+      content {
+        enabled = var.monitoring_enable_managed_prometheus
+      }
+    }
   }
 
   dynamic "resource_usage_export_config" {

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -284,3 +284,9 @@ variable "monitoring_config_enable_components" {
   description = "Monitoring configuration for the cluster"
   type        = list(string)
 }
+
+variable "monitoring_enable_managed_prometheus" {
+  type        = bool
+  description = "Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
+  default     = false
+}

--- a/google_gke/versions.tf
+++ b/google_gke/versions.tf
@@ -3,12 +3,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 4.51.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.0"
+      version = "~> 4.51.0"
     }
   }
 


### PR DESCRIPTION
“Managed Service for Prometheus will be on by default in new GKE standard clusters”. This is so we can start rolling it out on our shared clusters. 

r?