### PR TITLE
feat(google_gke): fix shared_vpc_outputs

### DIFF
--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -119,11 +119,11 @@ variable "shared_vpc_outputs" {
         ip_cidr_range = string
         range_name    = string
       })
-      additional_ip_ranges = map(map(string))
     })
-    subnet_name   = string
-    subnetwork    = string
-    subnetwork_id = string
+    additional_ip_ranges = map(map(string))
+    subnet_name          = string
+    subnetwork           = string
+    subnetwork_id        = string
   })
 }
 


### PR DESCRIPTION
Moves `additional_ip_ranges` map to conform with the actual VPC output.

r?