### PR TITLE
feat: allow deployments from multiple Github environments

### DIFF
--- a/google_deployment_accounts/main.tf
+++ b/google_deployment_accounts/main.tf
@@ -12,7 +12,9 @@ resource "google_service_account" "account" {
 resource "google_service_account_iam_binding" "github-actions-access" {
   service_account_id = google_service_account.account.name
   role               = "roles/iam.workloadIdentityUser"
-  members = [
-    "principal://iam.googleapis.com/projects/${var.wip_project_number}/locations/global/workloadIdentityPools/${var.wip_name}/subject/repo:${var.github_repository}:environment:${var.environment}",
-  ]
+  members = (
+    length(var.gha_environments) > 0 ?
+    [for env in var.gha_environments : format("%s:%s", "principal://iam.googleapis.com/projects/${var.wip_project_number}/locations/global/workloadIdentityPools/${var.wip_name}/subject/repo:${var.github_repository}:environment", env)] :
+    ["principal://iam.googleapis.com/projects/${var.wip_project_number}/locations/global/workloadIdentityPools/${var.wip_name}/subject/repo:${var.github_repository}:environment:${var.environment}", ]
+  )
 }

--- a/google_deployment_accounts/variables.tf
+++ b/google_deployment_accounts/variables.tf
@@ -9,6 +9,12 @@ variable "environment" {
   type        = string
 }
 
+variable "gha_environments" {
+  description = "Github environments from which to deploy. If specified, this overrides the environment variable."
+  type        = list(string)
+  default     = []
+}
+
 variable "project" {
   type    = string
   default = null

--- a/google_deployment_accounts/variables.tf
+++ b/google_deployment_accounts/variables.tf
@@ -9,6 +9,11 @@ variable "environment" {
   type        = string
 }
 
+# Note that it is never wise to use the gha_environments variable to bypass
+# any required protection rules you may have for pushing to the production
+# environment. Ideally, you should have at least one Github environment that
+# requires manual approval for deploying to production, and that particular
+# Github environment should be included in the gha_environments list.
 variable "gha_environments" {
   description = "Github environments from which to deploy. If specified, this overrides the environment variable."
   type        = list(string)


### PR DESCRIPTION
The default deployment service accounts, i.e. deploy-{dev,stage,prod}, are each tied to a specific environment. Therefore, they can only deploy from the respective tied environment. However, there are instances where we need to deploy from multiple environments using the same service account. This pull request aims to address this specific use case.