### PR TITLE
fix: 400 error when updating existing redis instances

### DIFF
--- a/google_redis/main.tf
+++ b/google_redis/main.tf
@@ -59,5 +59,10 @@ resource "google_redis_instance" "main" {
 
   lifecycle {
     prevent_destroy = true
+    ignore_changes = [
+      # We may be able remove this after the upstream module releases
+      # https://github.com/GoogleCloudPlatform/magic-modules/pull/8261
+      maintenance_schedule,
+    ]
   }
 }


### PR DESCRIPTION
We ran into the same issue documented in https://github.com/hashicorp/terraform-provider-google/issues/11871 This PR adds a workaround to the issue.