### PR TITLE
feat(google_cloudsql_mysql): optionally enable private path for Google Cloud Services

### DIFF
--- a/google_cloudsql_mysql/README.md
+++ b/google_cloudsql_mysql/README.md
@@ -41,7 +41,6 @@ output "mysql_database" {
   sensitive = true
   value     = module.mysql_database
 }
-
 ```
 
 ## Example with more
@@ -104,7 +103,6 @@ output "mysql_database" {
   sensitive = true
   value     = module.mysql_database
 }
-
 ```
 
 ## Inputs
@@ -124,28 +122,30 @@ output "mysql_database" {
 | <a name="input_db_mem_gb"></a> [db\_mem\_gb](#input\_db\_mem\_gb) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"12"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether the instance is protected from deletion (TF) | `bool` | `true` | no |
 | <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Whether the instance is protected from deletion (API) | `bool` | `true` | no |
+| <a name="input_enable_private_path_for_google_cloud_services"></a> [enable\_private\_path\_for\_google\_cloud\_services](#input\_enable\_private\_path\_for\_google\_cloud\_services) | If true, will allow Google Cloud Services access over private IP. | `bool` | `false` | no |
 | <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | If true, will assign a public IP to database instance. | `bool` | `false` | no |
 | <a name="input_force_ha"></a> [force\_ha](#input\_force\_ha) | If set to true, create a mysql replica for HA. Currently the availability\_type works only for postgres | `bool` | `false` | no |
 | <a name="input_instance_version"></a> [instance\_version](#input\_instance\_version) | Version of database. Use this field if you need to spin up a new database instance. | `string` | `"v1"` | no |
-| <a name="input_ip_configuration_require_ssl"></a> [ip\_configuration\_require\_ssl](#input\_ip\_configuration\_require\_ssl) | n/a | `bool` | `true` | no |
-| <a name="input_maintenance_window_day"></a> [maintenance\_window\_day](#input\_maintenance\_window\_day) | n/a | `number` | `2` | no |
-| <a name="input_maintenance_window_hour"></a> [maintenance\_window\_hour](#input\_maintenance\_window\_hour) | n/a | `number` | `16` | no |
-| <a name="input_maintenance_window_update_track"></a> [maintenance\_window\_update\_track](#input\_maintenance\_window\_update\_track) | n/a | `string` | `"stable"` | no |
+| <a name="input_ip_configuration_require_ssl"></a> [ip\_configuration\_require\_ssl](#input\_ip\_configuration\_require\_ssl) | Enforces SSL connections over IP | `bool` | `true` | no |
+| <a name="input_maintenance_window_day"></a> [maintenance\_window\_day](#input\_maintenance\_window\_day) | Maintenance window day | `number` | `2` | no |
+| <a name="input_maintenance_window_hour"></a> [maintenance\_window\_hour](#input\_maintenance\_window\_hour) | Maintenance window hour | `number` | `16` | no |
+| <a name="input_maintenance_window_update_track"></a> [maintenance\_window\_update\_track](#input\_maintenance\_window\_update\_track) | Receive updates earlier (canary) or later (stable) | `string` | `"stable"` | no |
 | <a name="input_network"></a> [network](#input\_network) | Network where the private peering should attach. | `string` | `"default"` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | `null` | no |
-| <a name="input_query_insights_enabled"></a> [query\_insights\_enabled](#input\_query\_insights\_enabled) | See: https://cloud.google.com/sql/docs/mysql/using-query-insights | `bool` | `false` | no |
-| <a name="input_query_plans_per_minute"></a> [query\_plans\_per\_minute](#input\_query\_plans\_per\_minute) | query insights: sampling rate | `number` | `5` | no |
-| <a name="input_query_string_length"></a> [query\_string\_length](#input\_query\_string\_length) | query insights: length of queries | `number` | `1024` | no |
-| <a name="input_record_application_tags"></a> [record\_application\_tags](#input\_record\_application\_tags) | query insights: store application tags | `bool` | `false` | no |
-| <a name="input_record_client_address"></a> [record\_client\_address](#input\_record\_client\_address) | query insights: store client ip address | `bool` | `false` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID | `string` | `null` | no |
+| <a name="input_query_insights_enabled"></a> [query\_insights\_enabled](#input\_query\_insights\_enabled) | Enable / disable Query Insights (See: https://cloud.google.com/sql/docs/mysql/using-query-insights) | `bool` | `false` | no |
+| <a name="input_query_plans_per_minute"></a> [query\_plans\_per\_minute](#input\_query\_plans\_per\_minute) | Query Insights: sampling rate | `number` | `5` | no |
+| <a name="input_query_string_length"></a> [query\_string\_length](#input\_query\_string\_length) | Query Insights: length of queries | `number` | `1024` | no |
 | <a name="input_realm"></a> [realm](#input\_realm) | Realm e.g., nonprod. | `string` | `""` | no |
-| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | `"us-west1"` | no |
+| <a name="input_record_application_tags"></a> [record\_application\_tags](#input\_record\_application\_tags) | Query Insights: storage application tags | `bool` | `false` | no |
+| <a name="input_record_client_address"></a> [record\_client\_address](#input\_record\_client\_address) | Query Insights: store client IP address | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region to use for Google SQL instance | `string` | `"us-west1"` | no |
+| <a name="input_replica_availability_type_override"></a> [replica\_availability\_type\_override](#input\_replica\_availability\_type\_override) | This OVERRIDES var.availability\_type for replicas (replicas use var.availability\_type per default).) | `string` | `""` | no |
 | <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of replicas to create | `number` | `0` | no |
 | <a name="input_replica_db_cpu"></a> [replica\_db\_cpu](#input\_replica\_db\_cpu) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"2"` | no |
 | <a name="input_replica_db_mem_gb"></a> [replica\_db\_mem\_gb](#input\_replica\_db\_mem\_gb) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"12"` | no |
-| <a name="input_replica_availability_type_override"></a> [replica\_availability\_type\_override](#input\_replica\_availability\_type\_override) | This OVERRIDES var.availability\_type for replica instances | `string` | `""` | no |
+| <a name="input_replica_enable_private_path_for_google_cloud_services"></a> [replica\_enable\_private\_path\_for\_google\_cloud\_services](#input\_replica\_enable\_private\_path\_for\_google\_cloud\_services) | This OVERRIDES var.enable\_private\_path\_for\_google\_cloud\_services for replicas (replicas use var.enable\_private\_path\_for\_google\_cloud\_services per default). | `bool` | `null` | no |
+| <a name="input_replica_region_override"></a> [replica\_region\_override](#input\_replica\_region\_override) | This OVERRIDES var.region for replicas (replicas use var.region per default). | `string` | `""` | no |
 | <a name="input_replica_tier_override"></a> [replica\_tier\_override](#input\_replica\_tier\_override) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica\_db\_cpu and var.replica\_db\_mem\_gb | `string` | `""` | no |
-| <a name="input_replica_region_override"></a> [replica\_region\_override](#input\_replica\_region\_override) | replica instance region, this OVERRIDES var.region for replica instances. | `string` | `""` | no |
 | <a name="input_tier_override"></a> [tier\_override](#input\_tier\_override) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.db\_cpu and var.db\_mem\_gb | `string` | `""` | no |
 
 ## Outputs
@@ -158,5 +158,7 @@ output "mysql_database" {
 | <a name="output_private_ip_address"></a> [private\_ip\_address](#output\_private\_ip\_address) | n/a |
 | <a name="output_public_ip_address"></a> [public\_ip\_address](#output\_public\_ip\_address) | n/a |
 | <a name="output_replica_instance"></a> [replica\_instance](#output\_replica\_instance) | n/a |
+| <a name="output_replica_private_ip_address"></a> [replica\_private\_ip\_address](#output\_replica\_private\_ip\_address) | n/a |
+| <a name="output_replica_public_ip_address"></a> [replica\_public\_ip\_address](#output\_replica\_public\_ip\_address) | n/a |
 | <a name="output_self_link"></a> [self\_link](#output\_self\_link) | n/a |
 | <a name="output_service_account"></a> [service\_account](#output\_service\_account) | n/a |

--- a/google_cloudsql_mysql/main.tf
+++ b/google_cloudsql_mysql/main.tf
@@ -17,6 +17,8 @@ locals {
   ip_addresses = google_sql_database_instance.primary.ip_address
 
   enable_ha = var.realm == "prod" ? true : false
+
+  replica_enable_private_path_for_google_cloud_services = coalesce(var.replica_enable_private_path_for_google_cloud_services, var.enable_private_path_for_google_cloud_services)
 }
 
 resource "google_sql_database_instance" "primary" {
@@ -54,9 +56,10 @@ resource "google_sql_database_instance" "primary" {
     }
 
     ip_configuration {
-      ipv4_enabled    = var.enable_public_ip
-      private_network = var.network
-      require_ssl     = var.ip_configuration_require_ssl
+      ipv4_enabled                                  = var.enable_public_ip
+      private_network                               = var.network
+      require_ssl                                   = var.ip_configuration_require_ssl
+      enable_private_path_for_google_cloud_services = var.enable_private_path_for_google_cloud_services
       dynamic "authorized_networks" {
         for_each = var.authorized_networks
         content {
@@ -129,9 +132,10 @@ resource "google_sql_database_instance" "replica" {
     }
 
     ip_configuration {
-      ipv4_enabled    = var.enable_public_ip
-      private_network = var.network
-      require_ssl     = var.ip_configuration_require_ssl
+      ipv4_enabled                                  = var.enable_public_ip
+      private_network                               = var.network
+      require_ssl                                   = var.ip_configuration_require_ssl
+      enable_private_path_for_google_cloud_services = local.replica_enable_private_path_for_google_cloud_services
       dynamic "authorized_networks" {
         for_each = var.authorized_networks
         content {

--- a/google_cloudsql_mysql/main.tf
+++ b/google_cloudsql_mysql/main.tf
@@ -18,7 +18,7 @@ locals {
 
   enable_ha = var.realm == "prod" ? true : false
 
-  replica_enable_private_path_for_google_cloud_services = coalesce(var.replica_enable_private_path_for_google_cloud_services, var.enable_private_path_for_google_cloud_services)
+  replica_enable_private_path_for_google_cloud_services = var.replica_enable_private_path_for_google_cloud_services == false ? false : coalesce(var.replica_enable_private_path_for_google_cloud_services, var.enable_private_path_for_google_cloud_services)
 }
 
 resource "google_sql_database_instance" "primary" {

--- a/google_cloudsql_mysql/variables.tf
+++ b/google_cloudsql_mysql/variables.tf
@@ -5,8 +5,9 @@ variable "availability_type" {
 }
 
 variable "project_id" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
+  description = "GCP Project ID"
 }
 
 variable "custom_database_name" {
@@ -110,7 +111,8 @@ variable "enable_public_ip" {
 }
 
 variable "region" {
-  default = "us-west1"
+  default     = "us-west1"
+  description = "Region to use for Google SQL instance"
 }
 
 variable "database_flags" {
@@ -135,45 +137,65 @@ variable "authorized_networks" {
 }
 
 variable "ip_configuration_require_ssl" {
-  default = true
+  default     = true
+  description = "Enforces SSL connections over IP"
 }
 
 variable "maintenance_window_day" {
   # Tuesday
-  default = 2
+  default     = 2
+  description = "Maintenance window day"
 }
 
 variable "maintenance_window_hour" {
   # UTC hour
-  default = 16
+  default     = 16
+  description = "Maintenance window hour"
 }
 
 variable "maintenance_window_update_track" {
-  default = "stable"
+  default     = "stable"
+  description = "Receive updates earlier (canary) or later (stable)"
 }
 
 variable "query_insights_enabled" {
-  description = "enable / disable query insights"
+  description = "Enable / disable Query Insights (See: https://cloud.google.com/sql/docs/mysql/using-query-insights)"
   type        = bool
   default     = false
 }
 
 variable "query_plans_per_minute" {
-  type    = number
-  default = 5
+  description = "Query Insights: sampling rate"
+  type        = number
+  default     = 5
 }
 
 variable "query_string_length" {
-  type    = number
-  default = 1024
+  description = "Query Insights: length of queries"
+  type        = number
+  default     = 1024
 }
 
 variable "record_application_tags" {
-  type    = bool
-  default = false
+  description = "Query Insights: storage application tags"
+  type        = bool
+  default     = false
 }
 
 variable "record_client_address" {
-  type    = bool
-  default = false
+  description = "Query Insights: store client IP address"
+  type        = bool
+  default     = false
+}
+
+variable "enable_private_path_for_google_cloud_services" {
+  type        = bool
+  default     = false
+  description = "If true, will allow Google Cloud Services access over private IP."
+}
+
+variable "replica_enable_private_path_for_google_cloud_services" {
+  type        = bool
+  description = "This OVERRIDES var.enable_private_path_for_google_cloud_services for replicas (replicas use var.enable_private_path_for_google_cloud_services per default)."
+  default     = null
 }


### PR DESCRIPTION
# What changed?
- Added support to optionally enable private path for Google Cloud Services (ie. BigQuery)
  - `enable_private_path_for_google_cloud_services`: Enables setting for primary instance and replica instance(s), if replicas are enabled -- default `false`
  - `replica_enable_private_path_for_google_cloud_services`: Overrides the above for replica instance(s) -- default `null`
  - With these settings disabled by default, existing CloudSQL MySQL instances should not be impacted by this change
- Fixed some variable descriptions as `terraform-docs` was removing stuff from the README that wasn't included in the variable descriptions
- Added descriptions for variables that didn't have any

# How was this tested?
In a project, I manually enabled this setting for enabling private paths for Google Cloud services on a replica DB instance (disabled on primary instance) and tested the following conditions using `terraform plan`:

- `enable_private_path_for_google_cloud_services=unset`, `replica_enable_private_path_for_google_cloud_services=unset`:
  - **Expected result**: No changes on primary, setting disabled on replica
  - **Actual result**: No changes on primary, setting disabled on replica **(PASS)**
- `enable_private_path_for_google_cloud_services=true`, `replica_enable_private_path_for_google_cloud_services=unset`:
  - **Expected result**: Setting enabled on primary, no changes on replica
  - **Actual result**: Setting enabled on primary, no changes on replica **(PASS)**
- `enable_private_path_for_google_cloud_services=unset`, `replica_enable_private_path_for_google_cloud_services=true`:
  - **Expected result**: No changes on primary, no changes on replica
  - **Actual result**: No changes on primary, no changes on replica **(PASS)**
- `enable_private_path_for_google_cloud_services=true`, `replica_enable_private_path_for_google_cloud_services=false`:
  - **Expected result**: Setting enabled on primary, setting disabled on replica
  - **Actual result**: Setting enabled on primary, setting disabled on replica **(PASS)**
- `enable_private_path_for_google_cloud_services=false`, `replica_enable_private_path_for_google_cloud_services=true`:
  - **Expected result**: No changes on primary, no changes on replica
  - **Actual result**: No changes on primary, no changes on replica **(PASS)**