### PR TITLE
feat(google_project-dns): Added sandbox as a new team_name option

### DIFF
--- a/google_project-dns/variables.tf
+++ b/google_project-dns/variables.tf
@@ -34,7 +34,7 @@ variable "team_name" {
   type        = string
 
   validation {
-    condition     = contains(["cloudops", "dataops", "dataservices", "platform", "servicessre", "webservices", "websre"], var.team_name)
-    error_message = "Valid values for team_name: cloudops, dataops, dataservices, platform, servicessre, webservices, websre."
+    condition     = contains(["cloudops", "dataops", "dataservices", "platform", "sandbox", "servicessre", "webservices", "websre"], var.team_name)
+    error_message = "Valid values for team_name: cloudops, dataops, dataservices, platform, sandbox, servicessre, webservices, websre."
   }
 }


### PR DESCRIPTION
We are working on spinning up a new sandbox shared cluster, this module is consumed by the bootstrapping process and a new sandbox team should be an option to keep things in line with other cluster resources.