### PR TITLE
feat(mozilla workgroup): OPST-1098 - Migrate internal workgroup to terraform-modules

### DIFF
--- a/mozilla_workgroup/README.md
+++ b/mozilla_workgroup/README.md
@@ -1,0 +1,76 @@
+# Mozilla Workgroup
+
+Builds on top of the [google workgroup module](../google_workgroup/) and contains constants for mozilla environments. This is the default to use for creating our internal tenants.
+
+<!-- START_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_workgroup"></a> [workgroup](#module\_workgroup) | github.com/mozilla/terraform-modules//google_workgroup | OPST-682 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ids"></a> [ids](#input\_ids) | List of workgroup identifiers to look up access for | `set(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_google_groups"></a> [google\_groups](#output\_google\_groups) | google groups associated with the input workgroups, unqualified |
+| <a name="output_members"></a> [members](#output\_members) | authoritative, fully-qualified list of members associated with the input workgroups |
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_workgroup"></a> [workgroup](#module\_workgroup) | github.com/mozilla/terraform-modules//google_workgroup | main |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ids"></a> [ids](#input\_ids) | List of workgroup identifiers to look up access for | `set(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_google_groups"></a> [google\_groups](#output\_google\_groups) | google groups associated with the input workgroups, unqualified |
+| <a name="output_members"></a> [members](#output\_members) | authoritative, fully-qualified list of members associated with the input workgroups |
+<!-- END_TF_DOCS -->

--- a/mozilla_workgroup/main.tf
+++ b/mozilla_workgroup/main.tf
@@ -1,5 +1,5 @@
 module "workgroup" {
-  source = "github.com/mozilla/terraform-modules//google_workgroup?ref=main"
+  source = "../google_workgroup"
   ids                           = var.ids
   roles                         = {}
   workgroup_outputs             = ["members", "google_groups"]

--- a/mozilla_workgroup/main.tf
+++ b/mozilla_workgroup/main.tf
@@ -1,0 +1,8 @@
+module "workgroup" {
+  source = "github.com/mozilla/terraform-modules//google_workgroup?ref=main"
+  ids                           = var.ids
+  roles                         = {}
+  workgroup_outputs             = ["members", "google_groups"]
+  terraform_remote_state_bucket = "moz-fx-platform-mgmt-global-tf"
+  terraform_remote_state_prefix = "projects/google-workspace-management"
+}

--- a/mozilla_workgroup/main.tf
+++ b/mozilla_workgroup/main.tf
@@ -1,5 +1,5 @@
 module "workgroup" {
-  source = "../google_workgroup"
+  source                        = "../google_workgroup"
   ids                           = var.ids
   roles                         = {}
   workgroup_outputs             = ["members", "google_groups"]

--- a/mozilla_workgroup/outputs.tf
+++ b/mozilla_workgroup/outputs.tf
@@ -1,0 +1,9 @@
+output "members" {
+  description = "authoritative, fully-qualified list of members associated with the input workgroups"
+  value       = module.workgroup.members
+}
+
+output "google_groups" {
+  description = "google groups associated with the input workgroups, unqualified"
+  value       = module.workgroup.google_groups
+}

--- a/mozilla_workgroup/variables.tf
+++ b/mozilla_workgroup/variables.tf
@@ -1,0 +1,9 @@
+variable "ids" {
+  type        = set(string)
+  description = "List of workgroup identifiers to look up access for"
+
+  validation {
+    condition     = alltrue([for i in var.ids : length(regexall("^workgroup:[a-zA-Z0-9-]+(/[a-zA-Z0-9\\.-]+)?$|^subgroup:[a-zA-Z0-9\\.-]+$", i)) > 0])
+    error_message = "Bad workgroup identifier format, must match workgroup:WORKGROUP[/SUBGROUP] or subgroup:SUBGROUP."
+  }
+}

--- a/mozilla_workgroup/versions.tf
+++ b/mozilla_workgroup/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.0"
+    }
+  }
+  required_version = "~> 1.0"
+}


### PR DESCRIPTION
We maintain a shim workgroup module in the *-infra repos to make it easier to reference workgroups. This means that this code is duplicated in several repos, and there is now drift. As part of consolidating permissions process and module, we will migrate workgroup module from the old location into this common one.