### PR TITLE
fix(google_gke): ignore initial_node_count in node pool lifecycle block

### DIFF
--- a/google_gke/cluster.tf
+++ b/google_gke/cluster.tf
@@ -280,6 +280,7 @@ resource "google_container_node_pool" "pools" {
     create_before_destroy = true
 
     ignore_changes = [
+      initial_node_count,
       node_config[0].oauth_scopes,
       node_config[0].metadata,
     ]


### PR DESCRIPTION
We ran into an issue where a node pool was going to be [recreated](https://github.com/mozilla-it/global-platform-admin/pull/1143), could have been related to a manual node pool change via the UI. It's [recommended](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#initial_node_count) to ignore initial_node_count as part of the lifecycle policy. 

r?