### PR TITLE
feat(google_gke): enable internal ip reservation for k8s api proxy

### DIFF
--- a/google_gke/k8s_api_proxy.tf
+++ b/google_gke/k8s_api_proxy.tf
@@ -1,0 +1,13 @@
+#
+# K8S API Proxy Setup
+#
+resource "google_compute_address" "static_v4_k8s_api_proxy_ip" {
+  count        = var.enable_k8s_api_proxy_ip ? 1 : 0
+  provider     = google-beta # At this time the beta provider is required to define labels
+  name         = format("k8s-api-proxy-%s-%s-ip-v4-internal", var.name, var.region)
+  description  = format("IPv4 Internal - k8s api proxy - name:%s region:%s", var.name, var.region)
+  subnetwork   = var.internal_lb_subnetworks[var.region].subnetwork
+  address_type = "INTERNAL"
+
+  labels = local.labels
+}

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -108,6 +108,12 @@ variable "enable_public_cidrs_access" {
   type        = bool
 }
 
+variable "enable_k8s_api_proxy_ip" {
+  default     = false
+  description = "Whether we reserve an internal private ip for the k8s_api_proxy. Defaults to false."
+  type        = bool
+}
+
 variable "shared_vpc_outputs" {
   default     = null
   description = "Sets networking-related variables based on a homegrown Shared VPC Terraform outputs data structure."
@@ -335,4 +341,17 @@ variable "enable_cost_allocation" {
   type        = bool
   description = "Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery"
   default     = false
+}
+
+variable "internal_lb_subnetworks" {
+  description = "Internal subnetworks associated with Shared VPC, segmented by region"
+  type = map(object({
+    ip_cidr_range = string
+    network       = string
+    region        = string
+    subnet_name   = string
+    subnetwork    = string
+    subnetwork_id = string
+  }))
+  default = null
 }

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -344,6 +344,7 @@ variable "enable_cost_allocation" {
 }
 
 variable "internal_lb_subnetworks" {
+  default     = null
   description = "Internal subnetworks associated with Shared VPC, segmented by region"
   type = map(object({
     ip_cidr_range = string
@@ -353,5 +354,4 @@ variable "internal_lb_subnetworks" {
     subnetwork    = string
     subnetwork_id = string
   }))
-  default = null
 }


### PR DESCRIPTION
Added the option to reserve a static internal IP address for each cluster. 

This is intended for the k8s api proxy service running in each cluster but could be used elsewhere. 