### PR TITLE
fix(google_gke): updating service_subnetworks variable

### DIFF
--- a/google_gke/k8s_api_proxy.tf
+++ b/google_gke/k8s_api_proxy.tf
@@ -6,7 +6,7 @@ resource "google_compute_address" "static_v4_k8s_api_proxy_ip" {
   provider     = google-beta # At this time the beta provider is required to define labels
   name         = format("k8s-api-proxy-%s-%s-ip-v4-internal", var.name, var.region)
   description  = format("IPv4 Internal - k8s api proxy - name:%s region:%s", var.name, var.region)
-  subnetwork   = var.internal_lb_subnetworks[var.region].subnetwork
+  subnetwork   = var.service_subnetworks[var.region].subnetwork
   address_type = "INTERNAL"
 
   labels = local.labels

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -343,9 +343,9 @@ variable "enable_cost_allocation" {
   default     = false
 }
 
-variable "internal_lb_subnetworks" {
+variable "service_subnetworks" {
   default     = null
-  description = "Internal subnetworks associated with Shared VPC, segmented by region"
+  description = "Service subnetworks associated with Shared VPC, segmented by region"
   type = map(object({
     ip_cidr_range = string
     network       = string


### PR DESCRIPTION
Updating `internal_lb_subnetworks` to `service_subnetworks` variable to better reflect what we need here. 

This static IP address will be consumed via internal service which needs to be within the cluster service subnet range and not the internal lb subnetworks provisioned for internal gateway services.