### PR TITLE
feat(google_gke): create dns record for k8s-api-proxy ip address

### DIFF
--- a/google_gke/k8s_api_proxy.tf
+++ b/google_gke/k8s_api_proxy.tf
@@ -12,3 +12,16 @@ resource "google_compute_address" "static_v4_k8s_api_proxy_ip" {
 
   labels = local.labels
 }
+
+resource "google_dns_record_set" "k8s_api_proxy_dns_name" {
+  count        = var.enable_k8s_api_proxy_ip ? 1 : 0
+  name         = "${local.k8s_api_proxy_name}.${var.project_outputs.zone_dns_name}"
+  managed_zone = var.project_outputs.zone_name
+
+  type = "A"
+  ttl  = 300
+
+  rrdatas = [
+    google_compute_address.static_v4_k8s_api_proxy_ip[0].address
+  ]
+}

--- a/google_gke/locals.tf
+++ b/google_gke/locals.tf
@@ -5,6 +5,9 @@ data "google_project" "project" {
 locals {
   cluster_name        = "${var.name}-${var.realm}"
   cluster_network_tag = "gke-${local.cluster_name}"
+  cluster_type        = var.enable_private_cluster ? "private" : "public"
+
+  k8s_api_proxy_name = "api-proxy-${local.cluster_type}-${var.region}"
 
   labels_defaults = {
     "realm"     = var.realm

--- a/google_gke/outputs.tf
+++ b/google_gke/outputs.tf
@@ -33,3 +33,8 @@ output "service_account" {
   description = "Cluster Service Account"
   value       = google_service_account.cluster_service_account.email
 }
+
+output "k8s_api_proxy_dns_name" {
+  description = "K8s api proxy dns record"
+  value       = google_dns_record_set.k8s_api_proxy_dns_name[0].name
+}

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -114,6 +114,18 @@ variable "enable_k8s_api_proxy_ip" {
   type        = bool
 }
 
+variable "project_outputs" {
+  default     = null
+  description = "Sets cluster-related variables based on a homegrown Project outputs data structure."
+  type = object({
+    id            = string
+    name          = string
+    number        = string
+    zone_dns_name = string
+    zone_name     = string
+  })
+}
+
 variable "shared_vpc_outputs" {
   default     = null
   description = "Sets networking-related variables based on a homegrown Shared VPC Terraform outputs data structure."


### PR DESCRIPTION
Creating new DNS records in the cluster DNS zone for the `k8s-api-proxy` service. 

Need to pass in project outputs to this module to pull DNS zone information. 