### PR TITLE
feat(google_gke_namespace_logging): create a bigquery linked dataset …

### DIFF
--- a/google_gke_namespace_logging/main.tf
+++ b/google_gke_namespace_logging/main.tf
@@ -49,3 +49,10 @@ resource "google_bigquery_dataset_iam_member" "logging_dataset_writer" {
   role       = "roles/bigquery.dataEditor"
   member     = var.logging_writer_service_account_member
 }
+
+resource "google_logging_linked_dataset" "namespace_linked_dataset" {
+  count       = var.log_analytics ? 1 : 0
+  link_id     = replace("gke-${local.tenant_namespace}-log-linked", "-", "_")
+  bucket      = google_logging_project_bucket_config.namespace[0].id
+  description = "Linked Dataset for GKE Namespace Logging ${local.tenant_namespace}"
+}


### PR DESCRIPTION
…to namespace logging bucket

Jira Ticket: https://mozilla-hub.atlassian.net/browse/OPST-1262

Creates a linked dataset in BigQuery when log_analytics is enabled, and so that you can query the data directly from BigQuery.

r?