### PR TITLE
feat(google_gke): add additional control plane metrics collection as

### DIFF
--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -344,7 +344,7 @@ variable "gateway_api_enabled" {
 }
 
 variable "monitoring_config_enable_components" {
-  default     = ["SYSTEM_COMPONENTS"]
+  default     = ["SYSTEM_COMPONENTS", "API_SERVER", "SCHEDULER", "CONTROLLER_MANAGER"]
   description = "Monitoring configuration for the cluster"
   type        = list(string)
 }

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -344,7 +344,7 @@ variable "gateway_api_enabled" {
 }
 
 variable "monitoring_config_enable_components" {
-  default     = ["SYSTEM_COMPONENTS", "API_SERVER", "SCHEDULER", "CONTROLLER_MANAGER"]
+  default     = ["SYSTEM_COMPONENTS", "APISERVER", "SCHEDULER", "CONTROLLER_MANAGER"]
   description = "Monitoring configuration for the cluster"
   type        = list(string)
 }


### PR DESCRIPTION
Jira Ticket: https://mozilla-hub.atlassian.net/browse/OPST-1270

To enable [control plane metric collection](https://cloud.google.com/kubernetes-engine/docs/how-to/configure-metrics#control-plane-metrics) on our clusters.

r?