### PR TITLE
feat(tenant): Allow tenant to start with number

### DIFF
--- a/google_gar/locals.tf
+++ b/google_gar/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  repository_id = replace(coalesce(var.repository_id, "${var.application}-${var.realm}"), "/^\\d/", "")
+}

--- a/google_gar/main.tf
+++ b/google_gar/main.tf
@@ -13,7 +13,7 @@ resource "google_project_service" "gar" {
 resource "google_artifact_registry_repository" "repository" {
   provider      = google-beta
   depends_on    = [google_project_service.gar]
-  repository_id = coalesce(var.repository_id, "${var.application}-${var.realm}")
+  repository_id = local.repository_id
   format        = var.format
   location      = var.location
   description   = var.description

--- a/google_project-dns/README.md
+++ b/google_project-dns/README.md
@@ -38,8 +38,8 @@ No modules.
 | <a name="input_parent_managed_zone"></a> [parent\_managed\_zone](#input\_parent\_managed\_zone) | GCP DNS managed zone to add the record. | `string` | n/a | yes |
 | <a name="input_parent_project_id"></a> [parent\_project\_id](#input\_parent\_project\_id) | GCP project\_id that contains DNS zones used for delegation | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project\_id where the zone will be provisioned. | `string` | n/a | yes |
-| <a name="input_realm"></a> [realm](#input\_realm) | Realm is a grouping of environments being one of: global, nonprod, prod | `string` | `""` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Name of SRE team, which should correspond to the top-level folder name | `string` | n/a | yes |
+| <a name="input_realm"></a> [realm](#input\_realm) | Realm is a grouping of environments being one of: global, nonprod, prod | `string` | `""` | no |
 
 ## Outputs
 

--- a/google_project-dns/locals.tf
+++ b/google_project-dns/locals.tf
@@ -1,5 +1,9 @@
 locals {
   parent_zone = "${var.realm}.${var.team_name}.mozgcp.net"
   dns_name    = "${var.app_name}.${local.parent_zone}."
-  zone_name   = "${var.app_name}-${var.realm}-${var.team_name}-mozgcp-net"
+  # https://cloud.google.com/dns/docs/error-messages
+  # The operation to create a managed zone can fail with this error if the
+  # managed zone name does not begin with a letter, end with a letter or digit,
+  # and contain only lowercase letters, digits, or dashes.
+  zone_name = replace("${var.app_name}-${var.realm}-${var.team_name}-mozgcp-net", "/^\\d/", "")
 }


### PR DESCRIPTION
I was getting some errors when creating a tenant that starts with a digit. It seems like some GCP resources cannot be created with the first character as a digit. This removes the digit match which 