### PR TITLE
fix(gke): Minimal version bump to pull in changes for state metrics

### DIFF
--- a/google_gke/versions.tf
+++ b/google_gke/versions.tf
@@ -3,12 +3,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.76.0"
+      version = "~> 4.82.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.76.0"
+      version = "~> 4.82.0"
     }
   }
 


### PR DESCRIPTION
Via release notes https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.82.0

In particular, https://github.com/hashicorp/terraform-provider-google/pull/15727/files