### PR TITLE
feat(google_cdn_backend_bucket): add bypass_cache_on_request_headers block to cdn_policy input

### DIFF
--- a/google_cdn_backend_bucket/.terraform.lock.hcl
+++ b/google_cdn_backend_bucket/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.37.0"
+  constraints = ">= 5.32.0"
+  hashes = [
+    "h1:wUeVrQ1ss9vQbb6HP+hSgtQ7efSliSdHRef1/TRef6k=",
+    "zh:00754c426ec8c2416d54904b25ebf3d831b5af4f02a20336d0a60d91897497d7",
+    "zh:0b4128affc12ace78d9cbd8aac308b992cc1829effba0ac761b4c3e9e37a36e2",
+    "zh:46afda4cdadc242b0a27acb181967b7a37768aa084c84593506490483fbdefd6",
+    "zh:4ad56e9d5ed5e05184bd0a23e17b6eb985c28e7ce23ce29fdf50daa5594ead69",
+    "zh:557b021f77bd97462b20519148f454158e6cf89eba5461ae6016568b317e1c87",
+    "zh:6552bb5e901e9fbcd95dc95b4e017dfd7c1eca465dd749f9c8afdc4ae2bf3213",
+    "zh:687347e31e69f2c4518abc057ad157ed4fd2b78e399b3a172bcab4277f7a235b",
+    "zh:a66bfc55856693fe82a81554abf7fd72b8ca2d56a08cb59c4769c15b1a1acea5",
+    "zh:a8b242c5aab000f2a27e934930a75656efb4a96fdb06a419b22ae0daffa6fba3",
+    "zh:da9e9b40d632f218a3e0bb88b8cf95b91485cee1eb2fd2a384d45c2619c36da4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fda7bd1578e4b40e9e2d0298c77b0ad9f4486abee8ad38755299dd4b06be54c7",
+  ]
+}

--- a/google_cdn_backend_bucket/README.md
+++ b/google_cdn_backend_bucket/README.md
@@ -13,7 +13,7 @@ this module builds a GCP Load Balancer with a backend bucket
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.32.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.37.0 |
 
 ## Modules
 
@@ -38,7 +38,7 @@ No modules.
 | <a name="input_addresses"></a> [addresses](#input\_addresses) | loadbalancer ips | `map(string)` | n/a | yes |
 | <a name="input_application"></a> [application](#input\_application) | n/a | `string` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | name of bucket to use for the CDN | `string` | n/a | yes |
-| <a name="input_cdn_policy"></a> [cdn\_policy](#input\_cdn\_policy) | cdn policy | <pre>object({<br>    cache_mode        = optional(string, "CACHE_ALL_STATIC")<br>    client_ttl        = optional(number, 3600)<br>    default_ttl       = optional(number, 3600)<br>    max_ttl           = optional(number, 86400)<br>    negative_caching  = optional(bool, true)<br>    serve_while_stale = optional(number, 86400)<br>  })</pre> | n/a | yes |
+| <a name="input_cdn_policy"></a> [cdn\_policy](#input\_cdn\_policy) | cdn policy | <pre>object({<br>    cache_mode        = optional(string, "CACHE_ALL_STATIC")<br>    client_ttl        = optional(number, 3600)<br>    default_ttl       = optional(number, 3600)<br>    max_ttl           = optional(number, 86400)<br>    negative_caching  = optional(bool, true)<br>    serve_while_stale = optional(number, 86400)<br>    bypass_cache_on_request_headers = optional(object({<br>      header_name = optional(string, "Cache-Control")<br>    }), null)<br>  })</pre> | n/a | yes |
 | <a name="input_certificates"></a> [certificates](#input\_certificates) | list of certificate ids to use on the https target proxy | `list(string)` | n/a | yes |
 | <a name="input_compression_mode"></a> [compression\_mode](#input\_compression\_mode) | n/a | `string` | `"DISABLED"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `string` | n/a | yes |

--- a/google_cdn_backend_bucket/main.tf
+++ b/google_cdn_backend_bucket/main.tf
@@ -18,6 +18,12 @@ resource "google_compute_backend_bucket" "default" {
     max_ttl           = var.cdn_policy.max_ttl
     negative_caching  = var.cdn_policy.negative_caching
     serve_while_stale = var.cdn_policy.serve_while_stale
+    dynamic "bypass_cache_on_request_headers" {
+      for_each = var.cdn_policy.bypass_cache_on_request_headers != null ? [var.cdn_policy.bypass_cache_on_request_headers] : []
+      content {
+        header_name = bypass_cache_on_request_headers.value.header_name
+      }
+    }
   }
 }
 

--- a/google_cdn_backend_bucket/variables.tf
+++ b/google_cdn_backend_bucket/variables.tf
@@ -45,5 +45,8 @@ variable "cdn_policy" {
     max_ttl           = optional(number, 86400)
     negative_caching  = optional(bool, true)
     serve_while_stale = optional(number, 86400)
+    bypass_cache_on_request_headers = optional(object({
+      header_name = optional(string, "Cache-Control")
+    }), null)
   })
 }


### PR DESCRIPTION
Because:
* Tecken needs a CDN with no caching in front of its public GCS bucket.
* Part of the config to disable caching for the CDN is not currently exposed on this module.

This commit:
* Updates the `cdn_policy` input to the module to pass an optional `bypass_cache_on_request_headers` key.