### PR TITLE
feat(google_cloudsql_mysql): Enable query insights by default

### DIFF
--- a/google_cloudsql_mysql/variables.tf
+++ b/google_cloudsql_mysql/variables.tf
@@ -173,7 +173,7 @@ variable "maintenance_window_update_track" {
 variable "query_insights_enabled" {
   description = "Enable / disable Query Insights (See: https://cloud.google.com/sql/docs/mysql/using-query-insights)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "query_plans_per_minute" {


### PR DESCRIPTION
While working on a PR I discovered that the postgres module enables query insights by default, but the mysql module disables them by default.

Given that enabling query insights does not require a restart, and the information is very useful for debugging database performance issues I decided to enable them by default.
