### PR TITLE
fix(google_cloudsql_postgres): Allow null values for connector_enforcement.

### DIFF
--- a/google_cloudsql_postgres/variables.tf
+++ b/google_cloudsql_postgres/variables.tf
@@ -14,7 +14,7 @@ variable "connector_enforcement" {
   description = "Enables the enforcement of Cloud SQL Auth Proxy or Cloud SQL connectors for all the connections. If enabled, all the direct connections are rejected."
 
   validation {
-    condition     = var.connector_enforcement == null || contains(["NOT_REQUIRED", "REQUIRED"], var.connector_enforcement)
+    condition     = var.connector_enforcement == null ? true : contains(["NOT_REQUIRED", "REQUIRED"], var.connector_enforcement)
     error_message = "Valid values for connector_enforcement: NOT_REQUIRED, REQUIRED"
   }
 }


### PR DESCRIPTION
This issue prevented me from deploying: https://github.com/mozilla-it/webservices-infra/pull/2654#issuecomment-2326543360

In Terraform, the logical or operator `||` does not short-circuit. As a result, the second part of the validation condition gets evaluated even when `connector_enforcement` is `null`, and for some reason that's not a valid second parameter to `contains()` (which makes no sense, but it is how it is).