### PR TITLE
feat(google_monitoring): add selected_regions option to uptime check

### DIFF
--- a/google_monitoring/README.md
+++ b/google_monitoring/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -32,4 +31,3 @@ No modules.
 ## Outputs
 
 No outputs.
-<!-- END_TF_DOCS -->

--- a/google_monitoring/README.md
+++ b/google_monitoring/README.md
@@ -1,3 +1,4 @@
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -26,8 +27,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
-| <a name="input_uptime_checks"></a> [uptime\_checks](#input\_uptime\_checks) | n/a | <pre>list(object({<br>    name                = string<br>    host                = string<br>    path                = string<br>    request_method      = optional(string, "GET")<br>    content_type        = optional(string)<br>    custom_content_type = optional(string)<br>    body                = optional(string)<br>    timeout             = optional(string, "60s")<br>    period              = optional(string, "300s")<br>    user_labels         = optional(map(string), {})<br><br>    accepted_response_status_codes = optional(list(object({<br>      status_value = number<br>    })), [])<br><br>    accepted_response_status_classes = optional(list(object({<br>      status_class = string<br>    })), [])<br><br>    content_matchers = optional(list(object({<br>      content = optional(string)<br>      matcher = optional(string)<br>    })), [])<br>  }))</pre> | `[]` | no |
+| <a name="input_uptime_checks"></a> [uptime\_checks](#input\_uptime\_checks) | n/a | <pre>list(object({<br>    name                = string<br>    host                = string<br>    path                = string<br>    request_method      = optional(string, "GET")<br>    content_type        = optional(string)<br>    custom_content_type = optional(string)<br>    body                = optional(string)<br>    timeout             = optional(string, "60s")<br>    period              = optional(string, "300s")<br>    user_labels         = optional(map(string), {})<br>    selected_regions    = optional(list(string), [])<br><br>    accepted_response_status_codes = optional(list(object({<br>      status_value = number<br>    })), [])<br><br>    accepted_response_status_classes = optional(list(object({<br>      status_class = string<br>    })), [])<br><br>    content_matchers = optional(list(object({<br>      content = optional(string)<br>      matcher = optional(string)<br>    })), [])<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 
 No outputs.
+<!-- END_TF_DOCS -->

--- a/google_monitoring/uptime_checks.tf
+++ b/google_monitoring/uptime_checks.tf
@@ -1,10 +1,11 @@
 resource "google_monitoring_uptime_check_config" "https" {
   for_each = { for uptime_check in var.uptime_checks : uptime_check.name => uptime_check }
 
-  display_name = each.value.name
-  timeout      = each.value.timeout
-  period       = each.value.period
-  user_labels  = each.value.user_labels
+  display_name     = each.value.name
+  timeout          = each.value.timeout
+  period           = each.value.period
+  user_labels      = each.value.user_labels
+  selected_regions = each.value.selected_regions
 
   http_check {
     path                = each.value.path

--- a/google_monitoring/variables.tf
+++ b/google_monitoring/variables.tf
@@ -14,7 +14,7 @@ variable "uptime_checks" {
     timeout             = optional(string, "60s")
     period              = optional(string, "300s")
     user_labels         = optional(map(string), {})
-    selected_regions    = optional(list(string), [])
+    selected_regions    = optional(list(string), ["EUROPE", "USA_OREGON", "USA_VIRGINIA"])
 
     accepted_response_status_codes = optional(list(object({
       status_value = number

--- a/google_monitoring/variables.tf
+++ b/google_monitoring/variables.tf
@@ -14,6 +14,7 @@ variable "uptime_checks" {
     timeout             = optional(string, "60s")
     period              = optional(string, "300s")
     user_labels         = optional(map(string), {})
+    selected_regions    = optional(list(string), [])
 
     accepted_response_status_codes = optional(list(object({
       status_value = number


### PR DESCRIPTION
As part of [OBS-191](https://mozilla-hub.atlassian.net/browse/OBS-191), I am writing a ["How to create an uptime check"](https://docs.google.com/document/d/1Q9BW41-hhHwt03uOsm4oKYUoJdmsxPGkPrpOcwmuNco/edit?usp=sharing) document.

One common use case we expect is for teams to only care about checks for a subset of all the global regions a Google Uptime Check checks from by default (e.g. maybe they only need checks from `"USA"` and `"EUROPE"`, and not from `"SOUTH_AMERICA"` or `"ASIA_PACIFIC"`). Since each checker costs us executions, it makes sense to have this option, so I've added it here.

I've tested it in https://github.com/mozilla-it/webservices-infra/pull/2698.