### PR TITLE
fix: add missing pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->
+
+## Changelog entry
+```
+TODO: Replace this inner text with a useful message
+for users of the affected modules!
+```

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,7 +1,0 @@
-branches:
-  - main
-
-plugins:
-  - "@semantic-release/commit-analyzer"
-  - "@semantic-release/release-notes-generator"
-  - "@semantic-release/github"


### PR DESCRIPTION
Add PR template that was meant to be included in https://github.com/mozilla/terraform-modules/pull/237
Clean up no longer needed releaserc.yaml.