### PR TITLE
fix: add bq dataViewer to folder_additional_roles

### DIFF
--- a/google_permissions/outputs.tf
+++ b/google_permissions/outputs.tf
@@ -4,6 +4,7 @@ locals {
   // and that already have have existing supporting resource definitions.
   folder_additional_roles = [
     "roles/bigquery.jobUser",
+    "roles/bigquery.dataViewer",
     "roles/redis.admin",
     "roles/logging.admin",
     "roles/monitoring.alertPolicyEditor",


### PR DESCRIPTION
Code in https://github.com/mozilla/terraform-modules/blob/main/google_permissions/other_roles.tf suggests this should be a role allowed to be added to `folder_roles` input

This roles absence from the locals defined here causes the error "You have specified an invalid folder role." to be raised when this option is attempted

<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
fix disallowed usage of defined additional folder role`roles/bigquery.dataViewer`  as an input for `var.folder_roles` 
```
