### PR TITLE
fix: only render readme if tf-docs.yml is present; move tf-docs step

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -20,13 +20,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Render terraform docs inside the README.md and push changes back to PR branch
-      uses: terraform-docs/gh-actions@v1.3.0
-      with:
-        working-dir: ${{ inputs.package-name }}
-        output-file: README.md
-        git-push: "true"
-        config-file: .terraform-docs.yml
     - name: Checkout all tags
       uses: actions/checkout@v4
       with:
@@ -94,6 +87,26 @@ runs:
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
+    - name: Check for terraform-docs.yml
+      id: tf_docs
+      shell: bash
+      env:
+        PACKAGE_NAME: ${{ inputs.package-name }}
+      run: |
+        TF_DOCS_PATH="$PACKAGE_NAME/.terraform-docs.yml"
+        if [ -f $TF_DOCS_PATH ] ; then
+          echo "tf_docs=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "tf_docs=false" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Render terraform docs inside the README.md and push changes back to PR branch
+      if: ${{ steps.tf_docs.outputs.tf_docs == 'true' }}
+      uses: terraform-docs/gh-actions@v1.3.0
+      with:
+        working-dir: ${{ inputs.package-name }}
+        output-file: README.md
+        git-push: "true"
+        config-file: .terraform-docs.yml
     - name: Sparse checkout unmodified changelogs from main
       uses: actions/checkout@v4
       with:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you want to ensure specific people or teams have to review changes to certain
 
 ### Documentation
 
-A `README.md` is required for each module, and CI will automatically regenerate it using the [tf-docs github action](https://github.com/terraform-docs/gh-actions).
+A `README.md` is required for each module, and CI will automatically regenerate it using the [tf-docs github action](https://github.com/terraform-docs/gh-actions) if your module has a `.terraform-docs.yml`.
 To include non-generated content in your README, place it outside the `<!-- BEGIN_TF_DOCS -->` block.
 
 ## Using these modules


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Change to GHA to only render readme if tf-docs.yml is present in module directory
Move tf-docs generation step to after checkout in composite action to save a checkout
```
