### PR TITLE
fix: re-added admin for owner for all, bad logic in other_roles

### DIFF
--- a/google_permissions/main.tf
+++ b/google_permissions/main.tf
@@ -67,7 +67,7 @@ resource "google_project_iam_member" "developers_secretmanager_secretVersionAdde
 
 // if admin_only is true OR var.use_entitlements is true, we don't create these permissions at all
 resource "google_folder_iam_binding" "owner" {
-  count   = var.admin_only || var.entitlement_enabled == true ? 0 : 1
+  #count   = var.admin_only || var.entitlement_enabled == true ? 0 : 1
   folder  = var.google_folder_id
   role    = "roles/owner"
   members = module.admins_workgroup.members

--- a/google_permissions/other_roles.tf
+++ b/google_permissions/other_roles.tf
@@ -10,7 +10,7 @@ resource "google_folder_iam_binding" "bq_job_user" {
   //
   // NOTE: this uses bq_data_viewer as well as the next resource block so that those we grant data viewer
   // also have to execute jobs so paired with .dataViewer
-  count  = contains(var.folder_roles, "roles/bigquery.jobUser") && !var.admin_only && var.entitlement_enabled ? 1 : 0
+  count  = contains(var.folder_roles, "roles/bigquery.jobUser") && !var.admin_only ? 1 : 0
   folder = var.google_folder_id
   role   = "roles/bigquery.jobUser"
   members = setunion(
@@ -20,7 +20,7 @@ resource "google_folder_iam_binding" "bq_job_user" {
 }
 
 resource "google_folder_iam_binding" "bq_data_viewer" {
-  count  = contains(var.folder_roles, "roles/bigquery.dataViewer") && !var.admin_only && var.entitlement_enabled ? 1 : 0
+  count  = contains(var.folder_roles, "roles/bigquery.dataViewer") && !var.admin_only ? 1 : 0
   folder = var.google_folder_id
   role   = "roles/bigquery.dataViewer"
   members = setunion(
@@ -32,7 +32,7 @@ resource "google_folder_iam_binding" "bq_data_viewer" {
 # roles/redis.admin as folder_role
 
 resource "google_folder_iam_binding" "developers_redis_admin" {
-  count   = contains(var.folder_roles, "roles/redis.admin") && !var.admin_only && var.entitlement_enabled ? 1 : 0
+  count   = contains(var.folder_roles, "roles/redis.admin") && !var.admin_only && !var.entitlement_enabled ? 1 : 0
   folder  = var.google_folder_id
   role    = "roles/redis.admin"
   members = module.developers_workgroup.members
@@ -42,7 +42,7 @@ resource "google_folder_iam_binding" "developers_redis_admin" {
 # roles/logging.admin as folder_role
 
 resource "google_folder_iam_binding" "developers_logging_admin" {
-  count   = contains(var.folder_roles, "roles/logging.admin") && !var.admin_only && var.entitlement_enabled ? 1 : 0
+  count   = contains(var.folder_roles, "roles/logging.admin") && !var.admin_only && !var.entitlement_enabled ? 1 : 0
   folder  = var.google_folder_id
   role    = "roles/logging.admin"
   members = module.developers_workgroup.members
@@ -52,7 +52,7 @@ resource "google_folder_iam_binding" "developers_logging_admin" {
 # roles/monitoring.alertPolicyEditor as folder_role
 
 resource "google_folder_iam_binding" "developers_monitoring_alertPolicyEditor" {
-  count   = contains(var.folder_roles, "roles/monitoring.alertPolicyEditor") && !var.admin_only && var.entitlement_enabled ? 1 : 0
+  count   = contains(var.folder_roles, "roles/monitoring.alertPolicyEditor") && !var.admin_only && !var.entitlement_enabled ? 1 : 0
   folder  = var.google_folder_id
   role    = "roles/monitoring.alertPolicyEditor"
   members = module.developers_workgroup.members
@@ -62,7 +62,7 @@ resource "google_folder_iam_binding" "developers_monitoring_alertPolicyEditor" {
 # roles/monitoring.notificationChannelEditor in as folder_role
 
 resource "google_folder_iam_binding" "developers_monitoring_notificationChannelEditor" {
-  count   = contains(var.folder_roles, "roles/monitoring.notificationChannelEditor") && !var.admin_only && var.entitlement_enabled ? 1 : 0
+  count   = contains(var.folder_roles, "roles/monitoring.notificationChannelEditor") && !var.admin_only ? 1 : 0
   folder  = var.google_folder_id
   role    = "roles/monitoring.notificationChannelEditor"
   members = module.developers_workgroup.members


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
google_permissions module: for entitlements, we removed GCP "owner" IAM permissions across the board. For the short/near term, we will continue granting "owner" to the admin group. This corrects that former change. Now, regardless, admin workgroup for the specified tenant/appcode will have "owner" permissions on the projects.

We also updated the `other_roles.tf` where there was one logic error and one over-application of locking things behind constraints.
```
