### PR TITLE
fix(docs): Sign commits for documentation changes

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -99,14 +99,35 @@ runs:
         else
           echo "tf_docs=false" >> "$GITHUB_OUTPUT"
         fi
-    - name: Render terraform docs inside the README.md and push changes back to PR branch
+    - name: Render terraform docs inside the README.md
       if: ${{ steps.tf_docs.outputs.tf_docs == 'true' }}
+      id: terraform_docs
       uses: terraform-docs/gh-actions@v1.3.0
       with:
         working-dir: ${{ inputs.package-name }}
         output-file: README.md
-        git-push: "true"
         config-file: .terraform-docs.yml
+    - name: If documentation is updated, push to PR branch with a signed commit
+      if: ${{ steps.terraform_docs.outputs.num_changed != '0' }}
+      env:
+        DESTINATION_BRANCH: ${{ github.event.pull_request.head.ref }}
+        FILE_TO_COMMIT: ${{ inputs.package-name }}/README.md
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        ### Signed commit workaround - if we do a normal `git commit` here, it will be unsigned
+        # GHA doesn't have a good native way to sign commits (https://github.com/actions/runner/issues/667)
+        # Commits submitted via the API do get signed, so do that instead - adapted from https://gist.github.com/swinton/03e84635b45c78353b1f71e41007fc7c
+        export TODAY=$( date -u '+%Y-%m-%d' )
+        export MESSAGE="chore(docs): ${FILE_TO_COMMIT}"
+        export SHA=$( git rev-parse $DESTINATION_BRANCH:$FILE_TO_COMMIT )
+        export CONTENT=$( base64 -i $FILE_TO_COMMIT )
+        gh api --method PUT /repos/:owner/:repo/contents/$FILE_TO_COMMIT \
+          --field message="$MESSAGE" \
+          --field content="$CONTENT" \
+          --field encoding="base64" \
+          --field branch="$DESTINATION_BRANCH" \
+          --field sha="$SHA"
     - name: Sparse checkout unmodified changelogs from main
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

Once again I need to change a lightbulb https://www.youtube.com/watch?v=AbSehcT19u0

Our story begins with 2 small PRs:
- https://github.com/mozilla/terraform-modules/pull/253
- https://github.com/mozilla/terraform-modules/pull/254

Between these two PRs I noticed that:
- I wasn't able to merge my PR, because it had some unsigned commits, and this repository requires signed commits
- The generated documentation was being duplicated by terraform-docs

The reason the generated documentation was being duplicated is because most of our README.md files are missing the block delimeters `<!-- BEGIN_TF_DOCS -->` and `<!-- END_TF_DOCS -->`.
So the generated content will be appended at the end of the file.
Well no worries, maybe I just need to add those blocks to our existing README.md files? https://github.com/mozilla/terraform-modules/pull/256
Close, but I think I need to add `.terraform-docs.yml` config file to every directory as well. And we need to sign the commits too! Alas

So this PR switches the README.md generation to use signed commits like #240 did.

## Changelog entry
```
fix(docs): Sign commits for documentation changes
```
