### PR TITLE
feat(google_gke): added configuration for control_plane_endpoints_config, updated versions and added variable to toggle

### DIFF
--- a/google_gke/README.md
+++ b/google_gke/README.md
@@ -254,15 +254,15 @@ Module creates an opinionated GKE cluster plus related resources within a Shared
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.35 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 5.35 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.11 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.35 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 5.35 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.11 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.11 |
 
 ## Resources
 
@@ -290,6 +290,7 @@ Module creates an opinionated GKE cluster plus related resources within a Shared
 | <a name="input_dns_cache"></a> [dns\_cache](#input\_dns\_cache) | The status of the NodeLocal DNSCache addon. | `bool` | `true` | no |
 | <a name="input_enable_cost_allocation"></a> [enable\_cost\_allocation](#input\_enable\_cost\_allocation) | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | <a name="input_enable_dataplane"></a> [enable\_dataplane](#input\_enable\_dataplane) | Whether to enable dataplane v2 on the cluster. Sets DataPath field. Defaults to false. | `bool` | `false` | no |
+| <a name="input_enable_dns_endpoint"></a> [enable\_dns\_endpoint](#input\_enable\_dns\_endpoint) | Enable external DNS endpoint for control plane access | `bool` | `false` | no |
 | <a name="input_enable_gcfs"></a> [enable\_gcfs](#input\_enable\_gcfs) | Enable Google Container File System (gcfs) image streaming. | `bool` | `true` | no |
 | <a name="input_enable_k8s_api_proxy_ip"></a> [enable\_k8s\_api\_proxy\_ip](#input\_enable\_k8s\_api\_proxy\_ip) | Whether we reserve an internal private ip for the k8s\_api\_proxy. Defaults to false. | `bool` | `false` | no |
 | <a name="input_enable_network_egress_export"></a> [enable\_network\_egress\_export](#input\_enable\_network\_egress\_export) | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. Doesn't work with Shared VPC (https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-usage-metering). Defaults to false. | `bool` | `false` | no |

--- a/google_gke/cluster.tf
+++ b/google_gke/cluster.tf
@@ -81,6 +81,12 @@ resource "google_container_cluster" "primary" {
     gcp_public_cidrs_access_enabled = var.enable_public_cidrs_access
   }
 
+  control_plane_endpoints_config {
+    dns_endpoint_config {
+      allow_external_traffic = var.enable_dns_endpoint
+    }
+  }
+
   dynamic "private_cluster_config" {
     for_each = var.enable_private_cluster ? [1] : []
 

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -7,6 +7,12 @@ variable "description" {
   type        = string
 }
 
+variable "enable_dns_endpoint" {
+  default     = false
+  description = "Enable external DNS endpoint for control plane access"
+  type        = bool
+}
+
 variable "kubernetes_version" {
   default     = "latest"
   description = "The Kubernetes version of the masters. If set to 'latest' it will pull latest available version. Defaults to 'latest'."

--- a/google_gke/versions.tf
+++ b/google_gke/versions.tf
@@ -3,12 +3,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.35"
+      version = ">= 6.11"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.35"
+      version = ">= 6.11"
     }
   }
 


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Adding control_plane_endpoints_config configuration, private access to the control plane is enabled by default, and a variable toggles public access. 

This will allow authorized users to access the control plane of our clusters without using our bastions.
```
Docs: https://cloud.google.com/blog/products/containers-kubernetes/new-dns-based-endpoint-for-the-gke-control-plane