### PR TITLE
Adding additional permissions for FxA devs to be able to view job his…

### DIFF
--- a/google_permissions/other_roles.tf
+++ b/google_permissions/other_roles.tf
@@ -29,10 +29,10 @@ resource "google_folder_iam_binding" "bq_data_viewer" {
   )
 }
 
-resource "google_folder_iam_binding" "bq_resource_admin" {
-  count   = contains(var.folder_roles, "roles/bigquery.resourceAdmin") && !var.admin_only ? 1 : 0
+resource "google_folder_iam_binding" "bq_resource_viewer" {
+  count   = contains(var.folder_roles, "roles/bigquery.resourceViewer") && !var.admin_only ? 1 : 0
   folder  = var.google_folder_id
-  role    = "roles/bigquery.resourceAdmin"
+  role    = "roles/bigquery.resourceViewer"
   members = module.developers_workgroup.members
 }
 

--- a/google_permissions/other_roles.tf
+++ b/google_permissions/other_roles.tf
@@ -30,9 +30,9 @@ resource "google_folder_iam_binding" "bq_data_viewer" {
 }
 
 resource "google_folder_iam_binding" "bq_resource_admin" {
-  count  = contains(var.folder_roles, "roles/bigquery.resourceAdmin") && !var.admin_only ? 1 : 0
-  folder = var.google_folder_id
-  role   = "roles/bigquery.resourceAdmin"
+  count   = contains(var.folder_roles, "roles/bigquery.resourceAdmin") && !var.admin_only ? 1 : 0
+  folder  = var.google_folder_id
+  role    = "roles/bigquery.resourceAdmin"
   members = module.developers_workgroup.members
 }
 

--- a/google_permissions/other_roles.tf
+++ b/google_permissions/other_roles.tf
@@ -29,6 +29,33 @@ resource "google_folder_iam_binding" "bq_data_viewer" {
   )
 }
 
+resource "google_folder_iam_binding" "bq_resource_admin" {
+  count  = contains(var.folder_roles, "roles/bigquery.resourceAdmin") && !var.admin_only ? 1 : 0
+  folder = var.google_folder_id
+  role   = "roles/bigquery.resourceAdmin"
+  members = module.developers_workgroup.members
+}
+
+# roles/cloudtasks.queueAdmin as folder_role
+
+resource "google_folder_iam_binding" "cloudtasks_queue_admin" {
+  count   = contains(var.folder_roles, "roles/cloudtasks.queueAdmin") && !var.admin_only ? 1 : 0
+  folder  = var.google_folder_id
+  role    = "roles/cloudtasks.queueAdmin"
+  members = module.developers_workgroup.members
+
+}
+
+# roles/cloudtasks.taskRunner as folder_role
+
+resource "google_folder_iam_binding" "cloudtasks_task_runner" {
+  count   = contains(var.folder_roles, "roles/cloudtasks.taskRunner") && !var.admin_only ? 1 : 0
+  folder  = var.google_folder_id
+  role    = "roles/cloudtasks.taskRunner"
+  members = module.developers_workgroup.members
+
+}
+
 # roles/redis.admin as folder_role
 
 resource "google_folder_iam_binding" "developers_redis_admin" {

--- a/google_permissions/outputs.tf
+++ b/google_permissions/outputs.tf
@@ -5,7 +5,7 @@ locals {
   folder_additional_roles = [
     "roles/bigquery.jobUser",
     "roles/bigquery.dataViewer",
-    "roles/bigquery.resourceAdmin",
+    "roles/bigquery.resourceViewer",
     "roles/redis.admin",
     "roles/logging.admin",
     "roles/monitoring.alertPolicyEditor",

--- a/google_permissions/outputs.tf
+++ b/google_permissions/outputs.tf
@@ -5,6 +5,7 @@ locals {
   folder_additional_roles = [
     "roles/bigquery.jobUser",
     "roles/bigquery.dataViewer",
+    "roles/bigquery.resourceAdmin",
     "roles/redis.admin",
     "roles/logging.admin",
     "roles/monitoring.alertPolicyEditor",
@@ -14,6 +15,8 @@ locals {
   project_additional_roles = [
     "roles/automl.editor",
     "roles/cloudsql.admin",
+    "roles/cloudtasks.queueAdmin",
+    "roles/cloudtasks.taskRunner",
     "roles/cloudtranslate.editor",
     "roles/editor",
     "roles/monitoring.uptimeCheckConfigEditor",


### PR DESCRIPTION
…tory for datasets in BQ as well as cloudtask queues. This is specifically for FxA to be able to support the inactive account deletion script that is being implemented

<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Adding the following roles to other_roles.tf and outputs.tf
 roles/cloudtasks.queueAdmin
 roles/cloudtasks.taskRunner
roles/bigquery.resourceViewer
```
