### PR TITLE
moving cloudtask roles to folder additional roles instead of project …

### DIFF
--- a/google_permissions/outputs.tf
+++ b/google_permissions/outputs.tf
@@ -6,6 +6,8 @@ locals {
     "roles/bigquery.jobUser",
     "roles/bigquery.dataViewer",
     "roles/bigquery.resourceViewer",
+    "roles/cloudtasks.queueAdmin",
+    "roles/cloudtasks.taskRunner",
     "roles/redis.admin",
     "roles/logging.admin",
     "roles/monitoring.alertPolicyEditor",
@@ -15,8 +17,6 @@ locals {
   project_additional_roles = [
     "roles/automl.editor",
     "roles/cloudsql.admin",
-    "roles/cloudtasks.queueAdmin",
-    "roles/cloudtasks.taskRunner",
     "roles/cloudtranslate.editor",
     "roles/editor",
     "roles/monitoring.uptimeCheckConfigEditor",


### PR DESCRIPTION
…to fix syntax issue

putting roles/cloudtasks.queueAdmin and roles/cloudtasks.taskRunner in the folder_additional_roles instead of project_additional_roles to allign with how it's being set in other_roles.tf.

<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Moving
 roles/cloudtasks.queueAdmin 
 roles/cloudtasks.taskRunner
to
 folder_additional_roles instead of project_additional_roles
```
