### PR TITLE
SRELEAD-301: Expose generated uptime checks in google_monitoring.

### DIFF
--- a/google_monitoring/README.md
+++ b/google_monitoring/README.md
@@ -10,5 +10,7 @@
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_uptime_checks"></a> [uptime\_checks](#output\_uptime\_checks) | n/a |
 <!-- END_TF_DOCS -->

--- a/google_monitoring/outputs.tf
+++ b/google_monitoring/outputs.tf
@@ -1,0 +1,3 @@
+output "uptime_checks" {
+  value = google_monitoring_uptime_check_config.https
+}


### PR DESCRIPTION
To set up alerting for Yardstick, I need access to the ids of the generated checks. Instead of exposing individual fields, I decided to simply expose the checks themselves, so all attributes can be accessed.

https://mozilla-hub.atlassian.net/browse/SRELEAD-301

## Changelog entry
```
The google_monitoring module now exposes the generated uptime checks as an output.
```
