### PR TITLE
fix(google_permissions) complete removal of var.entitlement_enabled from other_roles, add secret roles to default ent

### DIFF
--- a/google_permissions/other_roles.tf
+++ b/google_permissions/other_roles.tf
@@ -59,7 +59,7 @@ resource "google_folder_iam_binding" "cloudtasks_task_runner" {
 # roles/redis.admin as folder_role
 
 resource "google_folder_iam_binding" "developers_redis_admin" {
-  count   = contains(var.folder_roles, "roles/redis.admin") && !var.admin_only && !var.entitlement_enabled ? 1 : 0
+  count   = contains(var.folder_roles, "roles/redis.admin") && !var.admin_only ? 1 : 0
   folder  = var.google_folder_id
   role    = "roles/redis.admin"
   members = module.developers_workgroup.members
@@ -69,7 +69,7 @@ resource "google_folder_iam_binding" "developers_redis_admin" {
 # roles/logging.admin as folder_role
 
 resource "google_folder_iam_binding" "developers_logging_admin" {
-  count   = contains(var.folder_roles, "roles/logging.admin") && !var.admin_only && !var.entitlement_enabled ? 1 : 0
+  count   = contains(var.folder_roles, "roles/logging.admin") && !var.admin_only ? 1 : 0
   folder  = var.google_folder_id
   role    = "roles/logging.admin"
   members = module.developers_workgroup.members
@@ -79,7 +79,7 @@ resource "google_folder_iam_binding" "developers_logging_admin" {
 # roles/monitoring.alertPolicyEditor as folder_role
 
 resource "google_folder_iam_binding" "developers_monitoring_alertPolicyEditor" {
-  count   = contains(var.folder_roles, "roles/monitoring.alertPolicyEditor") && !var.admin_only && !var.entitlement_enabled ? 1 : 0
+  count   = contains(var.folder_roles, "roles/monitoring.alertPolicyEditor") && !var.admin_only ? 1 : 0
   folder  = var.google_folder_id
   role    = "roles/monitoring.alertPolicyEditor"
   members = module.developers_workgroup.members
@@ -97,161 +97,161 @@ resource "google_folder_iam_binding" "developers_monitoring_notificationChannelE
 }
 
 resource "google_project_iam_binding" "editor_nonprod" {
-  count   = contains(var.nonprod_roles, "roles/editor") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/editor") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/editor"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "automl_editor_prod" {
-  count   = contains(var.prod_roles, "roles/automl.editor") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/automl.editor") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/automl.editor"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_member" "cloudtranslate_editor_prod" {
-  for_each = contains(var.prod_roles, "roles/cloudtranslate.editor") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? toset(module.developers_workgroup.members) : toset([])
+  for_each = contains(var.prod_roles, "roles/cloudtranslate.editor") && !var.admin_only && var.google_prod_project_id != "" ? toset(module.developers_workgroup.members) : toset([])
   project  = var.google_prod_project_id
   role     = "roles/cloudtranslate.editor"
   member   = each.key
 }
 
 resource "google_project_iam_binding" "storage_objectadmin_prod" {
-  count   = contains(var.prod_roles, "roles/storage.objectAdmin") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/storage.objectAdmin") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/storage.objectAdmin"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "translationhub_admin_prod" {
-  count   = contains(var.prod_roles, "roles/translationhub.admin") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/translationhub.admin") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/translationhub.admin"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "bucket_admin" {
-  count   = contains(var.nonprod_roles, "roles/storage.admin") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/storage.admin") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/storage.admin"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "prod_bucket_admin" {
-  count   = contains(var.prod_roles, "roles/storage.admin") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/storage.admin") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/storage.admin"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "prod_developer_db_admin" {
-  count   = contains(var.prod_roles, "roles/cloudsql.admin") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/cloudsql.admin") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/cloudsql.admin"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "nonprod_developer_db_admin" {
-  count   = contains(var.nonprod_roles, "roles/cloudsql.admin") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/cloudsql.admin") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/cloudsql.admin"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "prod_developer_monitoring_uptimecheckconfigeditor" {
-  count   = contains(var.prod_roles, "roles/monitoring.uptimeCheckConfigEditor") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/monitoring.uptimeCheckConfigEditor") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/monitoring.uptimeCheckConfigEditor"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "nonprod_developer_monitoring_uptimecheckconfigeditor" {
-  count   = contains(var.nonprod_roles, "roles/monitoring.uptimeCheckConfigEditor") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/monitoring.uptimeCheckConfigEditor") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/monitoring.uptimeCheckConfigEditor"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "prod_developer_pubsub_editor" {
-  count   = contains(var.prod_roles, "roles/pubsub.editor") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/pubsub.editor") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/pubsub.editor"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "nonprod_developer_pubsub_editor" {
-  count   = contains(var.nonprod_roles, "roles/pubsub.editor") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/pubsub.editor") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/pubsub.editor"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "prod_developer_colabEnterpriseUser" {
-  count   = contains(var.prod_roles, "roles/aiplatform.colabEnterpriseUser") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/aiplatform.colabEnterpriseUser") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/aiplatform.colabEnterpriseUser"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "nonprod_developer_colabEnterpriseUser" {
-  count   = contains(var.nonprod_roles, "roles/aiplatform.colabEnterpriseUser") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/aiplatform.colabEnterpriseUser") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/aiplatform.colabEnterpriseUser"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "prod_developer_cloudsql_viewer" {
-  count   = contains(var.prod_roles, "roles/cloudsql.viewer") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/cloudsql.viewer") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/cloudsql.viewer"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "nonprod_developer_cloudsql_viewer" {
-  count   = contains(var.nonprod_roles, "roles/cloudsql.viewer") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/cloudsql.viewer") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/cloudsql.viewer"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "prod_developer_objectUser" {
-  count   = contains(var.prod_roles, "roles/storage.objectUser") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? 1 : 0
+  count   = contains(var.prod_roles, "roles/storage.objectUser") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id
   role    = "roles/storage.objectUser"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "nonprod_developer_objectUser" {
-  count   = contains(var.nonprod_roles, "roles/storage.objectUser") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/storage.objectUser") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/storage.objectUser"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_binding" "nonprod_developer_secretmanager_admin" {
-  count   = contains(var.nonprod_roles, "roles/secretmanager.admin") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/secretmanager.admin") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/secretmanager.admin"
   members = module.developers_workgroup.members
 }
 
 resource "google_project_iam_member" "prod_developer_secretmanager_secretAccessor" {
-  for_each = contains(var.prod_roles, "roles/secretmanager.secretAccessor") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? toset(module.developers_workgroup.members) : toset([])
+  for_each = contains(var.prod_roles, "roles/secretmanager.secretAccessor") && !var.admin_only && var.google_prod_project_id != "" ? toset(module.developers_workgroup.members) : toset([])
   project  = var.google_prod_project_id
   role     = "roles/secretmanager.secretAccessor"
   member   = each.value
 }
 
 resource "google_project_iam_member" "prod_developer_secretmanager_secretVersionAdder" {
-  for_each = contains(var.prod_roles, "roles/secretmanager.secretVersionAdder") && !var.admin_only && var.entitlement_enabled && var.google_prod_project_id != "" ? toset(module.developers_workgroup.members) : toset([])
+  for_each = contains(var.prod_roles, "roles/secretmanager.secretVersionAdder") && !var.admin_only && var.google_prod_project_id != "" ? toset(module.developers_workgroup.members) : toset([])
   project  = var.google_prod_project_id
   role     = "roles/secretmanager.secretVersionAdder"
   member   = each.value
 }
 
 resource "google_project_iam_binding" "nonprod_developer_oath_config_editor" {
-  count   = contains(var.nonprod_roles, "roles/oauthconfig.editor") && !var.admin_only && var.entitlement_enabled && var.google_nonprod_project_id != "" ? 1 : 0
+  count   = contains(var.nonprod_roles, "roles/oauthconfig.editor") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
   project = var.google_nonprod_project_id
   role    = "roles/oauthconfig.editor"
   members = module.developers_workgroup.members

--- a/google_permissions/pam_entitlement.tf
+++ b/google_permissions/pam_entitlement.tf
@@ -7,6 +7,8 @@ locals {
     "roles/storage.admin",
     "roles/spanner.admin",
     "roles/cloudsql.admin",
+    "roles/secretmanager.secretAccessor",    // added for OPST-1833
+    "roles/secretmanager.secretVersionAdder" // added for OPST-1833
   ]
 
   // Populate the environments list dynamically


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
- complete removal of var.entitlement_enabled from other_roles.tf - at one point there was a reason for it, but as it exists, it is breaking legitimate usage
- added  roles/secretmanager.secretAccessor and  roles/secretmanager.secretVersionAdder to default admin entitlement per OPST-1833
```
