### PR TITLE
norelease: version:refname in tagging logic to avoid collisions

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
       run: |
         git fetch --tags
-        TAG=$(git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/$PACKAGE_NAME-[0-9].[0-9].[0-9]")
+        TAG=$(git for-each-ref --sort=-version:refname --count 1 --format="%(refname:short)" "refs/tags/$PACKAGE_NAME-[0-9].[0-9].[0-9]")
 
         if [ -z "$TAG" ] ; then
           echo "No git tag found for $PACKAGE_NAME, using 0.0.0 as previous version"


### PR DESCRIPTION
## Changelog entry
```
Use -version:rename instead of date in CI tagging logic to avoid collisions if things get tagged out of chronological order
To prevent things like https://github.com/mozilla/terraform-modules/actions/runs/13662382521
```
