### PR TITLE
fix(google-permissions) prod default entitlement doesn't match non-prod extra attr

### DIFF
--- a/google_permissions/pam_entitlement.tf
+++ b/google_permissions/pam_entitlement.tf
@@ -95,7 +95,7 @@ resource "google_privileged_access_manager_entitlement" "default_prod_entitlemen
   }
 
   eligible_users {
-    principals = local.module_outputs["default"].members
+    principals = local.module_outputs["default"]
   }
   privileged_access {
     gcp_iam_access {


### PR DESCRIPTION

## Changelog entry
```
bugfix - prod entitlement code didn't match non-prod. [default] has no attribute .members
```
