### PR TITLE
fix(google_fastly_waf): Remove provider configuration

### DIFF
--- a/google_fastly_waf/provider.tf
+++ b/google_fastly_waf/provider.tf
@@ -1,6 +1,0 @@
-# NGWAF SIGSCI
-provider "sigsci" {
-  corp     = "not_a_real_corp"
-  email    = "not_a_real_email"
-  password = "not_a_real_password_set_for_terraform_validate" # pragma: allowlist secret
-}


### PR DESCRIPTION
The provider is configured via environment variables in Atlantis, so it
doesn't need placeholder values.

<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Remove provider configuration
```
