### PR TITLE
fix(google-permissions) fix loop bug in slack project_feed - OPST-1914

### DIFF
--- a/google_permissions/pam_entitlement.tf
+++ b/google_permissions/pam_entitlement.tf
@@ -233,7 +233,7 @@ resource "google_privileged_access_manager_entitlement" "additional_entitlements
 # Create a feed that sends notifications about network resource updates.
 resource "google_cloud_asset_project_feed" "project_feed" {
   for_each     = var.entitlement_enabled && var.entitlement_slack_topic != "" ? toset(local.environments) : []
-  project      = local.environments[each.key]
+  project      = each.value == "nonprod" ? var.google_nonprod_project_id : var.google_prod_project_id
   feed_id      = var.feed_id
   content_type = "RESOURCE"
 


### PR DESCRIPTION
## Changelog entry

```
This pull request includes a change to the `google_permissions/pam_entitlement.tf` file. The change updates the project assignment logic for the `google_cloud_asset_project_feed` resource to differentiate between non-production and production environments.
```
