### PR TITLE
fix(fastly): Make subscription domain optional

### DIFF
--- a/google_fastly_waf/certificate.tf
+++ b/google_fastly_waf/certificate.tf
@@ -1,4 +1,5 @@
 resource "fastly_tls_subscription" "fastly" {
+  count                 = length(var.subscription_domains) > 0 ? 1 : 0
   domains               = [for domain in var.subscription_domains : domain.name]
   certificate_authority = "lets-encrypt"
 }

--- a/google_fastly_waf/outputs.tf
+++ b/google_fastly_waf/outputs.tf
@@ -3,5 +3,5 @@ output "ngwaf_edgesite_short_name" {
 }
 
 output "certificate_verification_information" {
-  value = fastly_tls_subscription.fastly[0].managed_dns_challenges
+  value = fastly_tls_subscription.fastly.*.managed_dns_challenges
 }

--- a/google_fastly_waf/outputs.tf
+++ b/google_fastly_waf/outputs.tf
@@ -3,5 +3,5 @@ output "ngwaf_edgesite_short_name" {
 }
 
 output "certificate_verification_information" {
-  value = fastly_tls_subscription.fastly.managed_dns_challenges
+  value = fastly_tls_subscription.fastly[0].managed_dns_challenges
 }


### PR DESCRIPTION
## Changelog entry
```
Allow creating a Fastly WAF without a separate subscription domain
```
