### PR TITLE
fix(google-permissions) create cloud asset service account for PAM slack - OPST-1914

### DIFF
--- a/google_permissions/pam_entitlement.tf
+++ b/google_permissions/pam_entitlement.tf
@@ -235,6 +235,8 @@ resource "google_privileged_access_manager_entitlement" "additional_entitlements
 // The project feed requires that cloudasset API is not only set up but also that the service account is created
 
 // Create a service account for the cloudasset API
+// ref: https://stackoverflow.com/questions/63785247/gcp-managed-service-account-is-not-created-for-cloud-asset-api
+//
 resource "google_project_service_identity" "cloud_asset_sa" {
   for_each = var.entitlement_enabled && var.entitlement_slack_topic != "" ? toset(local.environments) : []
   provider = google-beta

--- a/google_permissions/pam_entitlement.tf
+++ b/google_permissions/pam_entitlement.tf
@@ -230,7 +230,19 @@ resource "google_privileged_access_manager_entitlement" "additional_entitlements
   }
 }
 
-# Create a feed that sends notifications about network resource updates.
+// Needed for slack notifications for PAM activity from cloudasset to a central topic
+
+// The project feed requires that cloudasset API is not only set up but also that the service account is created
+
+// Create a service account for the cloudasset API
+resource "google_project_service_identity" "cloud_asset_sa" {
+  for_each = var.entitlement_enabled && var.entitlement_slack_topic != "" ? toset(local.environments) : []
+  provider = google-beta
+  project  = each.value == "nonprod" ? var.google_nonprod_project_id : var.google_prod_project_id
+  service  = "cloudasset.googleapis.com"
+}
+
+// Create a feed that sends notifications about network resource updates.
 resource "google_cloud_asset_project_feed" "project_feed" {
   for_each     = var.entitlement_enabled && var.entitlement_slack_topic != "" ? toset(local.environments) : []
   project      = each.value == "nonprod" ? var.google_nonprod_project_id : var.google_prod_project_id


### PR DESCRIPTION
## Changelog entry
```
* Added a new resource `google_project_service_identity` to create a service account for the Cloud Asset API. This ensures that the Cloud Asset API is properly set up with the necessary service account.
```
