### PR TITLE
OPST-2084 Add-in config setting for cluster autoscale behavior

### DIFF
--- a/google_gke/README.md
+++ b/google_gke/README.md
@@ -150,6 +150,7 @@ module "gke" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_autoscaling_profile"></a> [autoscaling\_profile](#input\_autoscaling\_profile) | Specify the profile to be used for autoscaling.  Defaults to 'BALANCED' | `string` | `"BALANCED"` | no |
 | <a name="input_create_resource_usage_export_dataset"></a> [create\_resource\_usage\_export\_dataset](#input\_create\_resource\_usage\_export\_dataset) | The ID of a BigQuery Dataset for using BigQuery as the destination of resource usage export. Defaults to empty string. | `bool` | `false` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the cluster | `string` | `null` | no |
 | <a name="input_disable_snat_status"></a> [disable\_snat\_status](#input\_disable\_snat\_status) | Whether the cluster disables default in-node sNAT rules. Defaults to false. | `bool` | `false` | no |

--- a/google_gke/cluster.tf
+++ b/google_gke/cluster.tf
@@ -19,6 +19,10 @@ resource "google_container_cluster" "primary" {
   project         = local.project_id
   resource_labels = local.labels
 
+  cluster_autoscaling {
+    autoscaling_profile = var.autoscaling_profile
+  }
+
   release_channel {
     channel = var.release_channel
   }

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -412,3 +412,9 @@ variable "service_subnetworks" {
     subnetwork_id = string
   }))
 }
+
+variable "autoscaling_profile" {
+  description = "Specify the profile to be used for autoscaling.  Defaults to 'BALANCED'"
+  type        = string
+  default     = "BALANCED"
+}


### PR DESCRIPTION
## Changelog entry
```
Adding config setting for cluster autoscale behavior
Default will continue to be 'BALANCED', can specify 'OPTIMIZE_UTILIZATION' for cost savings in nonprod environments
```
