### PR TITLE
chore(google_gke): White space change to trigger tagging of new release

### DIFF
--- a/google_gke/k8s_api_proxy.tf
+++ b/google_gke/k8s_api_proxy.tf
@@ -1,6 +1,7 @@
 #
 # K8S API Proxy Setup
 #
+
 resource "google_compute_address" "static_v4_k8s_api_proxy_ip" {
   count        = var.enable_k8s_api_proxy_ip ? 1 : 0
   provider     = google-beta # At this time the beta provider is required to define labels


### PR DESCRIPTION
I broke the tagging with https://github.com/mozilla/terraform-modules/pull/280 as you can see in https://github.com/mozilla/terraform-modules/tags

Put in https://github.com/mozilla/terraform-modules/pull/282 to correct the issue and trying to trigger a tag + release

## Changelog entry
```
Fixing tagging in the release process
```
