### PR TITLE
feat(google_workload_identity): removed data source and updated outputs to use provided service account name and email

### DIFF
--- a/google_workload_identity/README.md
+++ b/google_workload_identity/README.md
@@ -9,6 +9,7 @@ accounts to go with it
 |------|-------------|------|---------|:--------:|
 | <a name="input_automount_service_account_token"></a> [automount\_service\_account\_token](#input\_automount\_service\_account\_token) | Enable automatic mounting of the service account token | `bool` | `false` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Cluster name. Required if using existing KSA. | `string` | `""` | no |
+| <a name="input_gcp_sa_email"></a> [gcp\_sa\_email](#input\_gcp\_sa\_email) | Email for an existing Google service account. | `string` | `null` | no |
 | <a name="input_gcp_sa_name"></a> [gcp\_sa\_name](#input\_gcp\_sa\_name) | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |
 | <a name="input_impersonate_service_account"></a> [impersonate\_service\_account](#input\_impersonate\_service\_account) | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | <a name="input_k8s_sa_name"></a> [k8s\_sa\_name](#input\_k8s\_sa\_name) | Name for the Kubernetes service account; overrides `var.name`. | `string` | `null` | no |

--- a/google_workload_identity/outputs.tf
+++ b/google_workload_identity/outputs.tf
@@ -26,5 +26,5 @@ output "gcp_service_account_name" {
 
 output "gcp_service_account" {
   description = "GCP service account."
-  value       = var.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]
+  value       = var.use_existing_gcp_sa ? var.gcp_sa_name : google_service_account.cluster_service_account[0]
 }

--- a/google_workload_identity/variables.tf
+++ b/google_workload_identity/variables.tf
@@ -14,6 +14,12 @@ variable "gcp_sa_name" {
   default     = null
 }
 
+variable "gcp_sa_email" {
+  description = "Email for an existing Google service account."
+  type        = string
+  default     = null
+}
+
 variable "use_existing_gcp_sa" {
   description = "Use an existing Google service account instead of creating one"
   type        = bool


### PR DESCRIPTION
## Changelog entry
```
* Removing data source for existing google_service_account, this is failing in hashicorp/google versions 6.13+ 
* Using `gcp_sa_name` directly instead of data source 
* Adding new `gcp_sa_email` variable that can be populated for existing service accounts
```
This update requires accompanying changes to the `google_gke_tenant` module to use the service account name instead of the email for existing service accounts. 