### PR TITLE
fix(google_gke_tenant): updated gcp_sa_name variable to use name instead of email

### DIFF
--- a/google_gke_tenant/gke_service_account.tf
+++ b/google_gke_tenant/gke_service_account.tf
@@ -13,6 +13,7 @@ module "workload-identity-for-tenant-sa" {
   use_existing_k8s_sa = true
   use_existing_gcp_sa = true
   gcp_sa_name         = google_service_account.gke-account.name
+  gcp_sa_email        = google_service_account.gke-account.email
 }
 
 module "workload-identity-for-generic-tenant-sa" {
@@ -24,6 +25,7 @@ module "workload-identity-for-generic-tenant-sa" {
   use_existing_k8s_sa = true
   use_existing_gcp_sa = true
   gcp_sa_name         = google_service_account.gke-account.name
+  gcp_sa_email        = google_service_account.gke-account.email
 }
 
 module "workload-identity-for-tenant-external-secrets-sa" {
@@ -35,6 +37,7 @@ module "workload-identity-for-tenant-external-secrets-sa" {
   use_existing_k8s_sa = true
   use_existing_gcp_sa = true
   gcp_sa_name         = google_service_account.gke-account.name
+  gcp_sa_email        = google_service_account.gke-account.email
 }
 
 # permissions for use with External Secrets Operator in GKE

--- a/google_gke_tenant/gke_service_account.tf
+++ b/google_gke_tenant/gke_service_account.tf
@@ -12,7 +12,7 @@ module "workload-identity-for-tenant-sa" {
   project_id          = var.cluster_project_id
   use_existing_k8s_sa = true
   use_existing_gcp_sa = true
-  gcp_sa_name         = google_service_account.gke-account.email
+  gcp_sa_name         = google_service_account.gke-account.name
 }
 
 module "workload-identity-for-generic-tenant-sa" {
@@ -23,7 +23,7 @@ module "workload-identity-for-generic-tenant-sa" {
   project_id          = var.cluster_project_id
   use_existing_k8s_sa = true
   use_existing_gcp_sa = true
-  gcp_sa_name         = google_service_account.gke-account.email
+  gcp_sa_name         = google_service_account.gke-account.name
 }
 
 module "workload-identity-for-tenant-external-secrets-sa" {
@@ -34,7 +34,7 @@ module "workload-identity-for-tenant-external-secrets-sa" {
   project_id          = var.cluster_project_id
   use_existing_k8s_sa = true
   use_existing_gcp_sa = true
-  gcp_sa_name         = google_service_account.gke-account.email
+  gcp_sa_name         = google_service_account.gke-account.name
 }
 
 # permissions for use with External Secrets Operator in GKE


### PR DESCRIPTION
## Changelog entry
```
* Using service account name in `gcp_sa_name` variable and populating `gcp_sa_email` for existing service accounts 
```
Requires changes in https://github.com/mozilla/terraform-modules/pull/285 