### PR TITLE
fix(google_gke_tenant): pin gke_service_account module version

### DIFF
--- a/google_gke_tenant/gke_service_account.tf
+++ b/google_gke_tenant/gke_service_account.tf
@@ -5,7 +5,7 @@ resource "google_service_account" "gke-account" {
 }
 
 module "workload-identity-for-tenant-sa" {
-  source = "github.com/mozilla/terraform-modules//google_workload_identity?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_workload_identity?ref=v2.6.1"
 
   name                = "gha-${var.application}"
   namespace           = "${var.application}-${var.environment}"
@@ -16,7 +16,7 @@ module "workload-identity-for-tenant-sa" {
 }
 
 module "workload-identity-for-generic-tenant-sa" {
-  source = "github.com/mozilla/terraform-modules//google_workload_identity?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_workload_identity?ref=v2.6.1"
 
   name                = var.application
   namespace           = "${var.application}-${var.environment}"
@@ -27,7 +27,7 @@ module "workload-identity-for-generic-tenant-sa" {
 }
 
 module "workload-identity-for-tenant-external-secrets-sa" {
-  source = "github.com/mozilla/terraform-modules//google_workload_identity?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_workload_identity?ref=v2.6.1"
 
   name                = "external-secrets"
   namespace           = "${var.application}-${var.environment}"


### PR DESCRIPTION


## Changelog entry
```
Pinning google_workload_identity module in google_gke_tenant to the most recent functional release. 
```
