### PR TITLE
feat(google_cloudsql_mysql): add support for ENTERPRISE_PLUS on replicas

### DIFF
--- a/google_cloudsql_mysql/README.md
+++ b/google_cloudsql_mysql/README.md
@@ -110,8 +110,8 @@ output "mysql_database" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_application"></a> [application](#input\_application) | Application e.g., bouncer. | `any` | n/a | yes |
-| <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | A list of authorized\_network maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html | `list` | `[]` | no |
+| <a name="input_application"></a> [application](#input\_application) | Application e.g., bouncer. | `string` | n/a | yes |
+| <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | A list of authorized\_network maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html | `list(any)` | `[]` | no |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#availability_type | `string` | `"ZONAL"` | no |
 | <a name="input_component"></a> [component](#input\_component) | A logical component of an application | `string` | `"db"` | no |
 | <a name="input_connector_enforcement"></a> [connector\_enforcement](#input\_connector\_enforcement) | Enables the enforcement of Cloud SQL Auth Proxy or Cloud SQL connectors for all the connections. If enabled, all the direct connections are rejected. | `string` | `null` | no |
@@ -127,10 +127,10 @@ output "mysql_database" {
 | <a name="input_edition"></a> [edition](#input\_edition) | The edition of the instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`. | `string` | `"ENTERPRISE"` | no |
 | <a name="input_enable_private_path_for_google_cloud_services"></a> [enable\_private\_path\_for\_google\_cloud\_services](#input\_enable\_private\_path\_for\_google\_cloud\_services) | If true, will allow Google Cloud Services access over private IP. | `bool` | `false` | no |
 | <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | If true, will assign a public IP to database instance. | `bool` | `false` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Environment e.g., stage. | `any` | n/a | yes |
-| <a name="input_force_ha"></a> [force\_ha](#input\_force\_ha) | If set to true, create a mysql replica for HA. Currently the availability\_type works only for postgres | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment e.g., stage. | `string` | n/a | yes |
+| <a name="input_force_ha"></a> [force\_ha](#input\_force\_ha) | If set to true, create a mysql replica for HA. Currently the availability\_type works only for postgres | `string` | `false` | no |
 | <a name="input_instance_version"></a> [instance\_version](#input\_instance\_version) | Version of database. Use this field if you need to spin up a new database instance. | `string` | `"v1"` | no |
-| <a name="input_ip_configuration_ssl_mode"></a> [ip\_configuration\_ssl\_mode](#input\_ip\_configuration\_ssl\_mode) | n/a | `string` | `"ALLOW_UNENCRYPTED_AND_ENCRYPTED"` | no |
+| <a name="input_ip_configuration_ssl_mode"></a> [ip\_configuration\_ssl\_mode](#input\_ip\_configuration\_ssl\_mode) | Specify how SSL connection should be enforced in DB connections. Supported values are ALLOW\_UNENCRYPTED\_AND\_ENCRYPTED, ENCRYPTED\_ONLY, and TRUSTED\_CLIENT\_CERTIFICATE\_REQUIRED | `string` | `"ALLOW_UNENCRYPTED_AND_ENCRYPTED"` | no |
 | <a name="input_maintenance_window_day"></a> [maintenance\_window\_day](#input\_maintenance\_window\_day) | Maintenance window day | `number` | `2` | no |
 | <a name="input_maintenance_window_hour"></a> [maintenance\_window\_hour](#input\_maintenance\_window\_hour) | Maintenance window hour | `number` | `16` | no |
 | <a name="input_maintenance_window_update_track"></a> [maintenance\_window\_update\_track](#input\_maintenance\_window\_update\_track) | Receive updates earlier (canary) or later (stable) | `string` | `"stable"` | no |
@@ -147,6 +147,7 @@ output "mysql_database" {
 | <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of replicas to create | `number` | `0` | no |
 | <a name="input_replica_db_cpu"></a> [replica\_db\_cpu](#input\_replica\_db\_cpu) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"2"` | no |
 | <a name="input_replica_db_mem_gb"></a> [replica\_db\_mem\_gb](#input\_replica\_db\_mem\_gb) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"12"` | no |
+| <a name="input_replica_edition"></a> [replica\_edition](#input\_replica\_edition) | The edition of the replica instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`. | `string` | `"ENTERPRISE"` | no |
 | <a name="input_replica_enable_private_path_for_google_cloud_services"></a> [replica\_enable\_private\_path\_for\_google\_cloud\_services](#input\_replica\_enable\_private\_path\_for\_google\_cloud\_services) | This OVERRIDES var.enable\_private\_path\_for\_google\_cloud\_services for replicas (replicas use var.enable\_private\_path\_for\_google\_cloud\_services per default). | `bool` | `null` | no |
 | <a name="input_replica_region_override"></a> [replica\_region\_override](#input\_replica\_region\_override) | This OVERRIDES var.region for replicas (replicas use var.region per default). | `string` | `""` | no |
 | <a name="input_replica_tier_override"></a> [replica\_tier\_override](#input\_replica\_tier\_override) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica\_db\_cpu and var.replica\_db\_mem\_gb | `string` | `""` | no |

--- a/google_cloudsql_mysql/README.md
+++ b/google_cloudsql_mysql/README.md
@@ -128,7 +128,7 @@ output "mysql_database" {
 | <a name="input_enable_private_path_for_google_cloud_services"></a> [enable\_private\_path\_for\_google\_cloud\_services](#input\_enable\_private\_path\_for\_google\_cloud\_services) | If true, will allow Google Cloud Services access over private IP. | `bool` | `false` | no |
 | <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | If true, will assign a public IP to database instance. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment e.g., stage. | `string` | n/a | yes |
-| <a name="input_force_ha"></a> [force\_ha](#input\_force\_ha) | If set to true, create a mysql replica for HA. Currently the availability\_type works only for postgres | `string` | `false` | no |
+| <a name="input_force_ha"></a> [force\_ha](#input\_force\_ha) | If set to true, create a mysql replica for HA. Currently the availability\_type works only for postgres | `bool` | `false` | no |
 | <a name="input_instance_version"></a> [instance\_version](#input\_instance\_version) | Version of database. Use this field if you need to spin up a new database instance. | `string` | `"v1"` | no |
 | <a name="input_ip_configuration_ssl_mode"></a> [ip\_configuration\_ssl\_mode](#input\_ip\_configuration\_ssl\_mode) | Specify how SSL connection should be enforced in DB connections. Supported values are ALLOW\_UNENCRYPTED\_AND\_ENCRYPTED, ENCRYPTED\_ONLY, and TRUSTED\_CLIENT\_CERTIFICATE\_REQUIRED | `string` | `"ALLOW_UNENCRYPTED_AND_ENCRYPTED"` | no |
 | <a name="input_maintenance_window_day"></a> [maintenance\_window\_day](#input\_maintenance\_window\_day) | Maintenance window day | `number` | `2` | no |

--- a/google_cloudsql_mysql/main.tf
+++ b/google_cloudsql_mysql/main.tf
@@ -131,6 +131,8 @@ resource "google_sql_database_instance" "replica" {
 
     deletion_protection_enabled = var.deletion_protection_enabled
 
+    edition = var.replica_edition
+
     dynamic "database_flags" {
       for_each = var.database_flags
       content {

--- a/google_cloudsql_mysql/variables.tf
+++ b/google_cloudsql_mysql/variables.tf
@@ -1,19 +1,30 @@
-variable "availability_type" {
+variable "application" {
+  description = "Application e.g., bouncer."
   type        = string
-  default     = "ZONAL"
-  description = "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#availability_type"
 }
 
-variable "project_id" {
+variable "authorized_networks" {
+  description = "A list of authorized_network maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html"
+  default     = []
+  type        = list(any)
+}
+
+variable "availability_type" {
+  default     = "ZONAL"
+  description = "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#availability_type"
   type        = string
-  default     = null
-  description = "GCP Project ID"
+}
+
+variable "component" {
+  description = "A logical component of an application"
+  default     = "db"
+  type        = string
 }
 
 variable "connector_enforcement" {
-  type        = string
   default     = null
   description = "Enables the enforcement of Cloud SQL Auth Proxy or Cloud SQL connectors for all the connections. If enabled, all the direct connections are rejected."
+  type        = string
 
   validation {
     condition     = var.connector_enforcement == null ? true : contains(["NOT_REQUIRED", "REQUIRED"], var.connector_enforcement)
@@ -24,118 +35,19 @@ variable "connector_enforcement" {
 variable "custom_database_name" {
   default     = ""
   description = "Use this field for custom database name."
+  type        = string
 }
 
 variable "custom_replica_name" {
   default     = ""
   description = "Custom database replica name."
+  type        = string
 }
 
 variable "data_cache_enabled" {
-  type        = bool
   default     = true
   description = "Whether data cache is enabled for the instance. Only available for `ENTERPRISE_PLUS` edition instances."
-}
-
-variable "deletion_protection" {
-  default     = true
   type        = bool
-  description = "Whether the instance is protected from deletion (TF)"
-}
-
-variable "deletion_protection_enabled" {
-  default     = true
-  type        = bool
-  description = "Whether the instance is protected from deletion (API)"
-}
-
-variable "edition" {
-  type        = string
-  default     = "ENTERPRISE"
-  description = "The edition of the instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`."
-}
-
-variable "replica_count" {
-  default     = 0
-  description = "Number of replicas to create"
-}
-
-variable "application" {
-  description = "Application e.g., bouncer."
-}
-
-variable "environment" {
-  description = "Environment e.g., stage."
-}
-
-variable "component" {
-  description = "A logical component of an application"
-  default     = "db"
-}
-
-variable "realm" {
-  default     = ""
-  description = "Realm e.g., nonprod."
-}
-
-variable "db_cpu" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
-  default     = "2"
-}
-
-variable "db_mem_gb" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
-  default     = "12"
-}
-
-variable "replica_db_cpu" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
-  default     = "2"
-}
-
-variable "replica_db_mem_gb" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
-  default     = "12"
-}
-
-variable "tier_override" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.db_cpu and var.db_mem_gb"
-  default     = ""
-}
-
-variable "replica_tier_override" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica_db_cpu and var.replica_db_mem_gb"
-  default     = ""
-}
-
-variable "replica_region_override" {
-  description = "This OVERRIDES var.region for replicas (replicas use var.region per default)."
-  default     = ""
-}
-
-variable "replica_availability_type_override" {
-  description = "This OVERRIDES var.availability_type for replicas (replicas use var.availability_type per default).)"
-  default     = ""
-}
-
-variable "instance_version" {
-  default     = "v1"
-  description = "Version of database. Use this field if you need to spin up a new database instance."
-}
-
-variable "database_version" {
-  default     = "MYSQL_8_0"
-  description = "Version of MySQL to run"
-}
-
-variable "enable_public_ip" {
-  default     = false
-  description = "If true, will assign a public IP to database instance."
-}
-
-variable "region" {
-  default     = "us-west1"
-  description = "Region to use for Google SQL instance"
 }
 
 variable "database_flags" {
@@ -144,23 +56,75 @@ variable "database_flags" {
   type        = list(object({ name = string, value = string }))
 }
 
-variable "network" {
-  description = "Network where the private peering should attach."
-  default     = "default"
+variable "database_version" {
+  default     = "MYSQL_8_0"
+  description = "Version of MySQL to run"
+  type        = string
+}
+
+variable "db_cpu" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  default     = "2"
+  type        = string
+}
+
+variable "db_mem_gb" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  default     = "12"
+  type        = string
+}
+
+variable "deletion_protection" {
+  default     = true
+  description = "Whether the instance is protected from deletion (TF)"
+  type        = bool
+}
+
+variable "deletion_protection_enabled" {
+  default     = true
+  description = "Whether the instance is protected from deletion (API)"
+  type        = bool
+}
+
+variable "edition" {
+  default     = "ENTERPRISE"
+  description = "The edition of the instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`."
+  type        = string
+}
+
+variable "enable_private_path_for_google_cloud_services" {
+  default     = false
+  description = "If true, will allow Google Cloud Services access over private IP."
+  type        = bool
+}
+
+variable "enable_public_ip" {
+  default     = false
+  description = "If true, will assign a public IP to database instance."
+  type        = bool
+}
+
+variable "environment" {
+  description = "Environment e.g., stage."
+  type        = string
 }
 
 variable "force_ha" {
   description = "If set to true, create a mysql replica for HA. Currently the availability_type works only for postgres"
   default     = false
+  type        = string
 }
 
-variable "authorized_networks" {
-  description = "A list of authorized_network maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html"
-  default     = []
+variable "instance_version" {
+  default     = "v1"
+  description = "Version of database. Use this field if you need to spin up a new database instance."
+  type        = string
 }
 
 variable "ip_configuration_ssl_mode" {
-  default = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+  default     = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+  description = "Specify how SSL connection should be enforced in DB connections. Supported values are ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY, and TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+  type        = string
   validation {
     condition     = contains(["ALLOW_UNENCRYPTED_AND_ENCRYPTED", "ENCRYPTED_ONLY", "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"], var.ip_configuration_ssl_mode)
     error_message = "The ip_configuration_ssl_mode value must be one of ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY, or TRUSTED_CLIENT_CERTIFICATE_REQUIRED. Also ensure that ip_configuration_require_ssl value matches this variable."
@@ -171,57 +135,126 @@ variable "maintenance_window_day" {
   # Tuesday
   default     = 2
   description = "Maintenance window day"
+  type        = number
 }
 
 variable "maintenance_window_hour" {
   # UTC hour
   default     = 16
   description = "Maintenance window hour"
+  type        = number
 }
 
 variable "maintenance_window_update_track" {
   default     = "stable"
   description = "Receive updates earlier (canary) or later (stable)"
+  type        = string
+}
+
+variable "network" {
+  description = "Network where the private peering should attach."
+  default     = "default"
+  type        = string
+}
+
+variable "project_id" {
+  default     = null
+  description = "GCP Project ID"
+  type        = string
 }
 
 variable "query_insights_enabled" {
   description = "Enable / disable Query Insights (See: https://cloud.google.com/sql/docs/mysql/using-query-insights)"
-  type        = bool
   default     = true
+  type        = bool
 }
 
 variable "query_plans_per_minute" {
   description = "Query Insights: sampling rate"
-  type        = number
   default     = 5
+  type        = number
 }
 
 variable "query_string_length" {
   description = "Query Insights: length of queries"
-  type        = number
   default     = 1024
+  type        = number
+}
+
+variable "realm" {
+  default     = ""
+  description = "Realm e.g., nonprod."
+  type        = string
 }
 
 variable "record_application_tags" {
   description = "Query Insights: storage application tags"
-  type        = bool
   default     = false
+  type        = bool
 }
 
 variable "record_client_address" {
   description = "Query Insights: store client IP address"
-  type        = bool
   default     = false
+  type        = bool
 }
 
-variable "enable_private_path_for_google_cloud_services" {
-  type        = bool
-  default     = false
-  description = "If true, will allow Google Cloud Services access over private IP."
+variable "region" {
+  default     = "us-west1"
+  description = "Region to use for Google SQL instance"
+  type        = string
+}
+
+variable "replica_availability_type_override" {
+  description = "This OVERRIDES var.availability_type for replicas (replicas use var.availability_type per default).)"
+  default     = ""
+  type        = string
+}
+
+variable "replica_count" {
+  default     = 0
+  description = "Number of replicas to create"
+  type        = number
+}
+
+variable "replica_db_cpu" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  default     = "2"
+  type        = string
+}
+
+variable "replica_db_mem_gb" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  default     = "12"
+  type        = string
+}
+
+variable "replica_edition" {
+  default     = "ENTERPRISE"
+  description = "The edition of the replica instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`."
+  type        = string
 }
 
 variable "replica_enable_private_path_for_google_cloud_services" {
-  type        = bool
   description = "This OVERRIDES var.enable_private_path_for_google_cloud_services for replicas (replicas use var.enable_private_path_for_google_cloud_services per default)."
   default     = null
+  type        = bool
+}
+
+variable "replica_region_override" {
+  description = "This OVERRIDES var.region for replicas (replicas use var.region per default)."
+  default     = ""
+  type        = string
+}
+
+variable "replica_tier_override" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica_db_cpu and var.replica_db_mem_gb"
+  default     = ""
+  type        = string
+}
+
+variable "tier_override" {
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.db_cpu and var.db_mem_gb"
+  default     = ""
+  type        = string
 }

--- a/google_cloudsql_mysql/variables.tf
+++ b/google_cloudsql_mysql/variables.tf
@@ -112,7 +112,7 @@ variable "environment" {
 variable "force_ha" {
   description = "If set to true, create a mysql replica for HA. Currently the availability_type works only for postgres"
   default     = false
-  type        = string
+  type        = bool
 }
 
 variable "instance_version" {


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
This allows users to enable Cloud SQL Enterprise Plus on replica instances. To configure this, set `replica_edition = "ENTERPRISE_PLUS"` in upstream modules.

I also alphabetized variables.tf to make it easier to find things and explicitly defined types for each variable to get rid of warnings in IDEs.
```
