### PR TITLE
fix(google_gke_namespace_logging): Prevent loss of logs when modifying log sink

### DIFF
--- a/google_gke_namespace_logging/README.md
+++ b/google_gke_namespace_logging/README.md
@@ -22,8 +22,6 @@ module "gke_logging" {
 | <a name="input_application"></a> [application](#input\_application) | Application, e.g. bouncer. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. dev, stage, prod | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Location of the logging bucket. Supported regions https://cloud.google.com/logging/docs/region-support#bucket-regions | `string` | `"global"` | no |
-| <a name="input_log_analytics"></a> [log\_analytics](#input\_log\_analytics) | Enable log analytics for log bucket | `bool` | `false` | no |
-| <a name="input_log_destination"></a> [log\_destination](#input\_log\_destination) | Destination for tenant application logs. Can be bucket or bigquery | `string` | `"bucket"` | no |
 | <a name="input_logging_writer_service_account_member"></a> [logging\_writer\_service\_account\_member](#input\_logging\_writer\_service\_account\_member) | The unique\_writer\_identity service account that is provisioned when creating a Logging Sink | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | n/a | `string` | `null` | no |
 | <a name="input_retention_days"></a> [retention\_days](#input\_retention\_days) | Log retention for logs, values between 1 and 3650 days | `number` | `90` | no |

--- a/google_gke_namespace_logging/outputs.tf
+++ b/google_gke_namespace_logging/outputs.tf
@@ -1,12 +1,12 @@
 output "logging_bucket_id" {
-  value = var.log_destination == "bucket" ? google_logging_project_bucket_config.namespace[0].id : null
+  value = google_logging_project_bucket_config.namespace.id
 }
 
 output "logging_bucket_linked_dataset_id" {
   description = "Log Analytics BigQuery dataset id"
-  value       = var.log_analytics ? google_logging_linked_dataset.namespace_linked_dataset[0].bigquery_dataset[0].dataset_id : null
+  value       = google_logging_linked_dataset.namespace_linked_dataset.bigquery_dataset[0].dataset_id
 }
 
 output "logging_dataset_id" {
-  value = var.log_destination == "bigquery" ? google_bigquery_dataset.namespace[0].dataset_id : null
+  value = google_bigquery_dataset.namespace.dataset_id
 }

--- a/google_gke_namespace_logging/variables.tf
+++ b/google_gke_namespace_logging/variables.tf
@@ -29,15 +29,3 @@ variable "logging_writer_service_account_member" {
   type        = string
   description = "The unique_writer_identity service account that is provisioned when creating a Logging Sink"
 }
-
-variable "log_destination" {
-  type        = string
-  description = "Destination for tenant application logs. Can be bucket or bigquery"
-  default     = "bucket"
-}
-
-variable "log_analytics" {
-  type        = bool
-  description = "Enable log analytics for log bucket"
-  default     = false
-}


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/OPST-2378

When you set up a service in GCPv2 you can choose between Cloud Logging & BigQuery for storing logs.
The log sink is created in global-platform-admin, and the log sink destination is created in 
(dataservices|webservices)-infra. This split means that if you change the log sink from BigQuery to
Cloud Logging or vice versa you will lose logs written to the log sink until the log sink
destination has been created.

The fix is to always create both log sink destinations, and grant the unique writer identity
permissions to write to both.

<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Always create both log sink destinations to prevent loss of logs
```
