### PR TITLE
feat:add ability to override name suffix

### DIFF
--- a/google_cdn-external/README.md
+++ b/google_cdn-external/README.md
@@ -11,6 +11,7 @@
 | <a name="input_backend_timeout_sec"></a> [backend\_timeout\_sec](#input\_backend\_timeout\_sec) | Timeout for backend service. | `number` | `10` | no |
 | <a name="input_backend_type"></a> [backend\_type](#input\_backend\_type) | Backend type to create. Must be set to one of [service, bucket, service\_and\_bucket]. When service\_and\_bucket, the default backend is the service | `string` | `"service"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of GCS bucket to use as CDN backend. Required if backend\_type is set to 'bucket' or 'service\_and\_bucket'. | `string` | `""` | no |
+| <a name="input_bypass_cache_on_request_headers"></a> [bypass\_cache\_on\_request\_headers](#input\_bypass\_cache\_on\_request\_headers) | Headers to match when bypassing cache | `list(string)` | `[]` | no |
 | <a name="input_cache_key_policy"></a> [cache\_key\_policy](#input\_cache\_key\_policy) | Cache key policy config to be passed to backend service. | `map(any)` | `{}` | no |
 | <a name="input_cdn_policy"></a> [cdn\_policy](#input\_cdn\_policy) | CDN policy config to be passed to backend service. | `map(any)` | `{}` | no |
 | <a name="input_certs"></a> [certs](#input\_certs) | List of certificates ids. If this list is empty, this will be HTTP only. | `list(string)` | n/a | yes |

--- a/google_cdn-external/README.md
+++ b/google_cdn-external/README.md
@@ -7,6 +7,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_addresses"></a> [addresses](#input\_addresses) | IP Addresses. | <pre>object({<br/>    ipv4 = string,<br/>    ipv6 = string,<br/>  })</pre> | n/a | yes |
 | <a name="input_application"></a> [application](#input\_application) | Application name. | `string` | n/a | yes |
+| <a name="input_backend_bucket_name_override"></a> [backend\_bucket\_name\_override](#input\_backend\_bucket\_name\_override) | Force a particular name for CDN backend bucket. Should only be used for legacy infra. | `string` | n/a | yes |
 | <a name="input_backend_timeout_sec"></a> [backend\_timeout\_sec](#input\_backend\_timeout\_sec) | Timeout for backend service. | `number` | `10` | no |
 | <a name="input_backend_type"></a> [backend\_type](#input\_backend\_type) | Backend type to create. Must be set to one of [service, bucket, service\_and\_bucket]. When service\_and\_bucket, the default backend is the service | `string` | `"service"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of GCS bucket to use as CDN backend. Required if backend\_type is set to 'bucket' or 'service\_and\_bucket'. | `string` | `""` | no |
@@ -19,7 +20,6 @@
 | <a name="input_https_redirect"></a> [https\_redirect](#input\_https\_redirect) | Redirect from http to https. | `bool` | `true` | no |
 | <a name="input_log_sample_rate"></a> [log\_sample\_rate](#input\_log\_sample\_rate) | Sample rate for Cloud Logging. Must be in the interval [0, 1]. | `number` | `1` | no |
 | <a name="input_name"></a> [name](#input\_name) | Optional name of distribution. | `string` | `""` | no |
-| <a name="input_name_suffix_override"></a> [name\_suffix\_override](#input\_name\_suffix\_override) | Suffix to append to resource names. Should only be used to support legacy infra | `string` | `"cdn"` | no |
 | <a name="input_negative_caching_policy"></a> [negative\_caching\_policy](#input\_negative\_caching\_policy) | Negative caching policy config to be passed to backend service. | <pre>list(object({<br/>    code = string<br/>    ttl  = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_origin_fqdn"></a> [origin\_fqdn](#input\_origin\_fqdn) | Origin's fqdn: e.g., 'mozilla.org'. | `string` | n/a | yes |
 | <a name="input_origin_port"></a> [origin\_port](#input\_origin\_port) | Port to use for origin. | `number` | `443` | no |

--- a/google_cdn-external/README.md
+++ b/google_cdn-external/README.md
@@ -19,6 +19,7 @@
 | <a name="input_https_redirect"></a> [https\_redirect](#input\_https\_redirect) | Redirect from http to https. | `bool` | `true` | no |
 | <a name="input_log_sample_rate"></a> [log\_sample\_rate](#input\_log\_sample\_rate) | Sample rate for Cloud Logging. Must be in the interval [0, 1]. | `number` | `1` | no |
 | <a name="input_name"></a> [name](#input\_name) | Optional name of distribution. | `string` | `""` | no |
+| <a name="input_name_suffix_override"></a> [name\_suffix\_override](#input\_name\_suffix\_override) | Suffix to append to resource names. Should only be used to support legacy infra | `string` | `"cdn"` | no |
 | <a name="input_negative_caching_policy"></a> [negative\_caching\_policy](#input\_negative\_caching\_policy) | Negative caching policy config to be passed to backend service. | <pre>list(object({<br/>    code = string<br/>    ttl  = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_origin_fqdn"></a> [origin\_fqdn](#input\_origin\_fqdn) | Origin's fqdn: e.g., 'mozilla.org'. | `string` | n/a | yes |
 | <a name="input_origin_port"></a> [origin\_port](#input\_origin\_port) | Port to use for origin. | `number` | `443` | no |

--- a/google_cdn-external/main.tf
+++ b/google_cdn-external/main.tf
@@ -101,13 +101,14 @@ resource "google_compute_backend_bucket" "default" {
     for_each = var.cdn_policy != {} ? [1] : []
 
     content {
-      cache_mode                   = lookup(var.cdn_policy, "cache_mode", null)
-      client_ttl                   = lookup(var.cdn_policy, "client_ttl", null)
-      default_ttl                  = lookup(var.cdn_policy, "default_ttl", null)
-      max_ttl                      = lookup(var.cdn_policy, "max_ttl", null)
-      negative_caching             = lookup(var.cdn_policy, "negative_caching", null)
-      serve_while_stale            = lookup(var.cdn_policy, "serve_while_stale", null)
-      signed_url_cache_max_age_sec = lookup(var.cdn_policy, "signed_url_cache_max_age_sec", null)
+      cache_mode                      = lookup(var.cdn_policy, "cache_mode", null)
+      client_ttl                      = lookup(var.cdn_policy, "client_ttl", null)
+      default_ttl                     = lookup(var.cdn_policy, "default_ttl", null)
+      max_ttl                         = lookup(var.cdn_policy, "max_ttl", null)
+      negative_caching                = lookup(var.cdn_policy, "negative_caching", null)
+      serve_while_stale               = lookup(var.cdn_policy, "serve_while_stale", null)
+      signed_url_cache_max_age_sec    = lookup(var.cdn_policy, "signed_url_cache_max_age_sec", null)
+      bypass_cache_on_request_headers = lookup(var.cdn_policy, "bypass_cache_on_request_headers", null)
       dynamic "negative_caching_policy" {
         for_each = { for policy in var.negative_caching_policy : "${policy.code}.${policy.ttl}" => policy }
         content {

--- a/google_cdn-external/main.tf
+++ b/google_cdn-external/main.tf
@@ -3,7 +3,7 @@
  */
 
 locals {
-  name_prefix = join("-", [var.application, var.environment, var.name != "" ? "${var.name}-cdn" : "cdn"])
+  name_prefix = join("-", [var.application, var.environment, var.name != "" ? "${var.name}-${name_suffix_override}" : "cdn"])
   # when both a bucket and backend service are specified, prefer the backend
   # service as the default backend, and use backend_bucket_paths to route
   # specific paths to the backend bucket

--- a/google_cdn-external/main.tf
+++ b/google_cdn-external/main.tf
@@ -101,14 +101,19 @@ resource "google_compute_backend_bucket" "default" {
     for_each = var.cdn_policy != {} ? [1] : []
 
     content {
-      cache_mode                      = lookup(var.cdn_policy, "cache_mode", null)
-      client_ttl                      = lookup(var.cdn_policy, "client_ttl", null)
-      default_ttl                     = lookup(var.cdn_policy, "default_ttl", null)
-      max_ttl                         = lookup(var.cdn_policy, "max_ttl", null)
-      negative_caching                = lookup(var.cdn_policy, "negative_caching", null)
-      serve_while_stale               = lookup(var.cdn_policy, "serve_while_stale", null)
-      signed_url_cache_max_age_sec    = lookup(var.cdn_policy, "signed_url_cache_max_age_sec", null)
-      bypass_cache_on_request_headers = lookup(var.cdn_policy, "bypass_cache_on_request_headers", null)
+      cache_mode                   = lookup(var.cdn_policy, "cache_mode", null)
+      client_ttl                   = lookup(var.cdn_policy, "client_ttl", null)
+      default_ttl                  = lookup(var.cdn_policy, "default_ttl", null)
+      max_ttl                      = lookup(var.cdn_policy, "max_ttl", null)
+      negative_caching             = lookup(var.cdn_policy, "negative_caching", null)
+      serve_while_stale            = lookup(var.cdn_policy, "serve_while_stale", null)
+      signed_url_cache_max_age_sec = lookup(var.cdn_policy, "signed_url_cache_max_age_sec", null)
+      dynamic "bypass_cache_on_request_headers" {
+        for_each = var.bypass_cache_on_request_headers
+        content {
+          header_name = bypass_cache_on_request_headers.value
+        }
+      }
       dynamic "negative_caching_policy" {
         for_each = { for policy in var.negative_caching_policy : "${policy.code}.${policy.ttl}" => policy }
         content {

--- a/google_cdn-external/main.tf
+++ b/google_cdn-external/main.tf
@@ -3,7 +3,7 @@
  */
 
 locals {
-  name_prefix = join("-", [var.application, var.environment, var.name != "" ? "${var.name}-${name_suffix_override}" : "cdn"])
+  name_prefix = join("-", [var.application, var.environment, var.name != "" ? "${var.name}-${var.name_suffix_override}" : "cdn"])
   # when both a bucket and backend service are specified, prefer the backend
   # service as the default backend, and use backend_bucket_paths to route
   # specific paths to the backend bucket

--- a/google_cdn-external/main.tf
+++ b/google_cdn-external/main.tf
@@ -3,7 +3,7 @@
  */
 
 locals {
-  name_prefix = join("-", [var.application, var.environment, var.name != "" ? "${var.name}-${var.name_suffix_override}" : "cdn"])
+  name_prefix = join("-", [var.application, var.environment, var.name != "" ? "${var.name}-cdn" : "cdn"])
   # when both a bucket and backend service are specified, prefer the backend
   # service as the default backend, and use backend_bucket_paths to route
   # specific paths to the backend bucket
@@ -90,7 +90,7 @@ resource "google_compute_backend_service" "default" {
 resource "google_compute_backend_bucket" "default" {
   count = contains(["bucket", "service_and_bucket"], var.backend_type) ? 1 : 0
 
-  name        = local.name_prefix
+  name        = var.backend_bucket_name_override != "" ? var.backend_bucket_name_override : local.name_prefix
   bucket_name = var.bucket_name
   enable_cdn  = true
 

--- a/google_cdn-external/variables.tf
+++ b/google_cdn-external/variables.tf
@@ -135,8 +135,7 @@ variable "bucket_name" {
   description = "Name of GCS bucket to use as CDN backend. Required if backend_type is set to 'bucket' or 'service_and_bucket'."
 }
 
-variable "name_suffix_override" {
+variable "backend_bucket_name_override" {
   type        = string
-  default     = "cdn"
-  description = "Suffix to append to resource names. Should only be used to support legacy infra"
+  description = "Force a particular name for CDN backend bucket. Should only be used for legacy infra."
 }

--- a/google_cdn-external/variables.tf
+++ b/google_cdn-external/variables.tf
@@ -134,3 +134,9 @@ variable "bucket_name" {
   default     = ""
   description = "Name of GCS bucket to use as CDN backend. Required if backend_type is set to 'bucket' or 'service_and_bucket'."
 }
+
+variable "name_suffix_override" {
+  type        = string
+  default     = "cdn"
+  description = "Suffix to append to resource names. Should only be used to support legacy infra"
+}

--- a/google_cdn-external/variables.tf
+++ b/google_cdn-external/variables.tf
@@ -99,6 +99,12 @@ variable "negative_caching_policy" {
   default = []
 }
 
+variable "bypass_cache_on_request_headers" {
+  description = "Headers to match when bypassing cache"
+  type        = list(string)
+  default     = []
+}
+
 variable "log_sample_rate" {
   description = "Sample rate for Cloud Logging. Must be in the interval [0, 1]."
   type        = number


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Add ability to override backend bucket name to support legacy infra
Expose `bypass_cache_on_request_headers` arg 
```

Required by, and tested in https://github.com/mozilla-it/dataservices-infra/pull/722
