### PR TITLE
feat(google_cloudsql_mysql): enable data cache on replicas if enterprise plus

### DIFF
--- a/google_cloudsql_mysql/README.md
+++ b/google_cloudsql_mysql/README.md
@@ -145,6 +145,7 @@ output "mysql_database" {
 | <a name="input_region"></a> [region](#input\_region) | Region to use for Google SQL instance | `string` | `"us-west1"` | no |
 | <a name="input_replica_availability_type_override"></a> [replica\_availability\_type\_override](#input\_replica\_availability\_type\_override) | This OVERRIDES var.availability\_type for replicas (replicas use var.availability\_type per default).) | `string` | `""` | no |
 | <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of replicas to create | `number` | `0` | no |
+| <a name="input_replica_data_cache_enabled"></a> [replica\_data\_cache\_enabled](#input\_replica\_data\_cache\_enabled) | Whether data cache is enabled for the replica instance. Only available for `ENTERPRISE_PLUS` edition instances. | `bool` | `true` | no |
 | <a name="input_replica_db_cpu"></a> [replica\_db\_cpu](#input\_replica\_db\_cpu) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"2"` | no |
 | <a name="input_replica_db_mem_gb"></a> [replica\_db\_mem\_gb](#input\_replica\_db\_mem\_gb) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"12"` | no |
 | <a name="input_replica_edition"></a> [replica\_edition](#input\_replica\_edition) | The edition of the replica instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`. | `string` | `"ENTERPRISE"` | no |

--- a/google_cloudsql_mysql/main.tf
+++ b/google_cloudsql_mysql/main.tf
@@ -146,6 +146,14 @@ resource "google_sql_database_instance" "replica" {
       }
     }
 
+    dynamic "data_cache_config" {
+      for_each = var.replica_edition == "ENTERPRISE_PLUS" ? [1] : []
+
+      content {
+        data_cache_enabled = var.replica_data_cache_enabled
+      }
+    }
+
     ip_configuration {
       ipv4_enabled                                  = var.enable_public_ip
       private_network                               = var.network

--- a/google_cloudsql_mysql/variables.tf
+++ b/google_cloudsql_mysql/variables.tf
@@ -217,6 +217,12 @@ variable "replica_count" {
   type        = number
 }
 
+variable "replica_data_cache_enabled" {
+  default     = true
+  description = "Whether data cache is enabled for the replica instance. Only available for `ENTERPRISE_PLUS` edition instances."
+  type        = bool
+}
+
 variable "replica_db_cpu" {
   description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
   default     = "2"


### PR DESCRIPTION

<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Enables data cache on replica instances if Cloud SQL Enterprise Plus is enabled.
```
