### PR TITLE
feat(google_cloudsql_postgres): add support for ENTERPRISE_PLUS on replicas

### DIFF
--- a/google_cloudsql_postgres/README.md
+++ b/google_cloudsql_postgres/README.md
@@ -51,16 +51,16 @@ output "postgres_database" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_application"></a> [application](#input\_application) | Application e.g., bouncer. | `any` | n/a | yes |
-| <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | n/a | `list` | `[]` | no |
+| <a name="input_application"></a> [application](#input\_application) | Application e.g., bouncer. | `string` | n/a | yes |
+| <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | A list of authorized\_network maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html | `list(any)` | `[]` | no |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | high availability (REGIONAL) or single zone (ZONAL) | `string` | `"REGIONAL"` | no |
 | <a name="input_component"></a> [component](#input\_component) | A logical component of an application | `string` | `"db"` | no |
 | <a name="input_connector_enforcement"></a> [connector\_enforcement](#input\_connector\_enforcement) | Enables the enforcement of Cloud SQL Auth Proxy or Cloud SQL connectors for all the connections. If enabled, all the direct connections are rejected. | `string` | `null` | no |
 | <a name="input_custom_database_name"></a> [custom\_database\_name](#input\_custom\_database\_name) | Use this field for custom database name. | `string` | `""` | no |
 | <a name="input_custom_replica_name"></a> [custom\_replica\_name](#input\_custom\_replica\_name) | Custom database replica name. | `string` | `""` | no |
 | <a name="input_data_cache_enabled"></a> [data\_cache\_enabled](#input\_data\_cache\_enabled) | Whether data cache is enabled for the instance. Only available for `ENTERPRISE_PLUS` edition instances. | `bool` | `true` | no |
-| <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | A list of database flag maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html | `list` | `[]` | no |
-| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | n/a | `string` | `"POSTGRES_13"` | no |
+| <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | A list of database flag maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html | `list(any)` | `[]` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Postgres version e.g., POSTGRES\_13 | `string` | `"POSTGRES_13"` | no |
 | <a name="input_db_cpu"></a> [db\_cpu](#input\_db\_cpu) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"2"` | no |
 | <a name="input_db_mem_gb"></a> [db\_mem\_gb](#input\_db\_mem\_gb) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"12"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether the instance is protected from deletion (TF) | `bool` | `true` | no |
@@ -69,12 +69,12 @@ output "postgres_database" {
 | <a name="input_enable_insights_config_on_replica"></a> [enable\_insights\_config\_on\_replica](#input\_enable\_insights\_config\_on\_replica) | If true, will allow enable insights config on replica | `bool` | `false` | no |
 | <a name="input_enable_private_path_for_google_cloud_services"></a> [enable\_private\_path\_for\_google\_cloud\_services](#input\_enable\_private\_path\_for\_google\_cloud\_services) | If true, will allow Google Cloud Services access over private IP. | `bool` | `false` | no |
 | <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | If true, will assign a public IP to database instance. | `bool` | `false` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Environment e.g., stage. | `any` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment e.g., stage. | `string` | n/a | yes |
 | <a name="input_instance_version"></a> [instance\_version](#input\_instance\_version) | Version of database. Use this field if you need to spin up a new database instance. | `string` | `"v1"` | no |
-| <a name="input_ip_configuration_ssl_mode"></a> [ip\_configuration\_ssl\_mode](#input\_ip\_configuration\_ssl\_mode) | n/a | `string` | `"ALLOW_UNENCRYPTED_AND_ENCRYPTED"` | no |
-| <a name="input_maintenance_window_day"></a> [maintenance\_window\_day](#input\_maintenance\_window\_day) | n/a | `number` | `1` | no |
-| <a name="input_maintenance_window_hour"></a> [maintenance\_window\_hour](#input\_maintenance\_window\_hour) | n/a | `number` | `17` | no |
-| <a name="input_maintenance_window_update_track"></a> [maintenance\_window\_update\_track](#input\_maintenance\_window\_update\_track) | n/a | `string` | `"stable"` | no |
+| <a name="input_ip_configuration_ssl_mode"></a> [ip\_configuration\_ssl\_mode](#input\_ip\_configuration\_ssl\_mode) | Specify how SSL connection should be enforced in DB connections. Supported values are ALLOW\_UNENCRYPTED\_AND\_ENCRYPTED, ENCRYPTED\_ONLY, and TRUSTED\_CLIENT\_CERTIFICATE\_REQUIRED | `string` | `"ALLOW_UNENCRYPTED_AND_ENCRYPTED"` | no |
+| <a name="input_maintenance_window_day"></a> [maintenance\_window\_day](#input\_maintenance\_window\_day) | Maintenance window day | `number` | `1` | no |
+| <a name="input_maintenance_window_hour"></a> [maintenance\_window\_hour](#input\_maintenance\_window\_hour) | Maintenance window hour | `number` | `17` | no |
+| <a name="input_maintenance_window_update_track"></a> [maintenance\_window\_update\_track](#input\_maintenance\_window\_update\_track) | Receive updates after one week (canary) or after two weeks (stable) or after five weeks (week5) of notification. | `string` | `"stable"` | no |
 | <a name="input_network"></a> [network](#input\_network) | Network where the private peering should attach. | `string` | `"default"` | no |
 | <a name="input_password_validation_policy_complexity"></a> [password\_validation\_policy\_complexity](#input\_password\_validation\_policy\_complexity) | Require complex password, must contain an uppercase letter, lowercase letter, number, and symbol | `bool` | `false` | no |
 | <a name="input_password_validation_policy_disallow_username_substring"></a> [password\_validation\_policy\_disallow\_username\_substring](#input\_password\_validation\_policy\_disallow\_username\_substring) | Prevents the use of the username in the password | `bool` | `false` | no |
@@ -82,15 +82,17 @@ output "postgres_database" {
 | <a name="input_password_validation_policy_min_length"></a> [password\_validation\_policy\_min\_length](#input\_password\_validation\_policy\_min\_length) | Min length for password | `number` | `0` | no |
 | <a name="input_password_validation_policy_password_change_interval"></a> [password\_validation\_policy\_password\_change\_interval](#input\_password\_validation\_policy\_password\_change\_interval) | Specifies the minimum duration after which you can change the password in hours | `string` | `"0s"` | no |
 | <a name="input_password_validation_policy_reuse_interval"></a> [password\_validation\_policy\_reuse\_interval](#input\_password\_validation\_policy\_reuse\_interval) | Specifies the number of previous passwords that can't be reused | `number` | `0` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | `null` | no |
-| <a name="input_realm"></a> [realm](#input\_realm) | Realm e.g., nonprod. | `any` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID | `string` | `null` | no |
+| <a name="input_realm"></a> [realm](#input\_realm) | Realm e.g., nonprod. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Region where database should be provisioned. | `string` | `"us-west1"` | no |
 | <a name="input_replica_availability_type"></a> [replica\_availability\_type](#input\_replica\_availability\_type) | Allow setting availability configuration of replica | `string` | `"ZONAL"` | no |
-| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | n/a | `number` | `0` | no |
+| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of instances | `number` | `0` | no |
+| <a name="input_replica_data_cache_enabled"></a> [replica\_data\_cache\_enabled](#input\_replica\_data\_cache\_enabled) | Whether data cache is enabled for the replica instance. Only available for `ENTERPRISE_PLUS` edition instances. | `bool` | `true` | no |
 | <a name="input_replica_db_cpu"></a> [replica\_db\_cpu](#input\_replica\_db\_cpu) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"2"` | no |
 | <a name="input_replica_db_mem_gb"></a> [replica\_db\_mem\_gb](#input\_replica\_db\_mem\_gb) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing | `string` | `"12"` | no |
-| <a name="input_replica_region_override"></a> [replica\_region\_override](#input\_replica\_region\_override) | This OVERRIDES var.region for replicas (replicas use var.region per default). | `any` | `null` | no |
-| <a name="input_replica_tier_override"></a> [replica\_tier\_override](#input\_replica\_tier\_override) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica\_db\_cpu and var.replica\_db\_mem\_gb | `any` | `null` | no |
+| <a name="input_replica_edition"></a> [replica\_edition](#input\_replica\_edition) | The edition of the replica instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`. | `string` | `"ENTERPRISE"` | no |
+| <a name="input_replica_region_override"></a> [replica\_region\_override](#input\_replica\_region\_override) | This OVERRIDES var.region for replicas (replicas use var.region per default). | `string` | `null` | no |
+| <a name="input_replica_tier_override"></a> [replica\_tier\_override](#input\_replica\_tier\_override) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica\_db\_cpu and var.replica\_db\_mem\_gb | `string` | `null` | no |
 | <a name="input_tier_override"></a> [tier\_override](#input\_tier\_override) | See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.db\_cpu and var.db\_mem\_gb | `string` | `""` | no |
 
 ## Outputs

--- a/google_cloudsql_postgres/main.tf
+++ b/google_cloudsql_postgres/main.tf
@@ -42,11 +42,11 @@ resource "google_sql_database_instance" "primary" {
         password_change_interval    = var.password_validation_policy_password_change_interval
       }
     }
-    deletion_protection_enabled = var.deletion_protection_enabled
-    tier                        = local.tier
     availability_type           = var.availability_type
     connector_enforcement       = var.connector_enforcement
+    deletion_protection_enabled = var.deletion_protection_enabled
     edition                     = var.edition
+    tier                        = local.tier
 
     backup_configuration {
       enabled                        = true
@@ -142,17 +142,16 @@ resource "google_sql_database_instance" "replica" {
         password_change_interval    = var.password_validation_policy_password_change_interval
       }
     }
-    deletion_protection_enabled = var.deletion_protection_enabled
-    tier                        = local.replica_tier
     availability_type           = var.replica_availability_type
+    deletion_protection_enabled = var.deletion_protection_enabled
+    edition                     = var.replica_edition
+    tier                        = local.replica_tier
 
-    dynamic "insights_config" {
-      for_each = var.enable_insights_config_on_replica ? range(1) : []
+    dynamic "data_cache_config" {
+      for_each = var.replica_edition == "ENTERPRISE_PLUS" ? [1] : []
+
       content {
-        query_insights_enabled  = true
-        query_string_length     = 1024
-        record_application_tags = true
-        record_client_address   = true
+        data_cache_enabled = var.replica_data_cache_enabled
       }
     }
 
@@ -166,6 +165,16 @@ resource "google_sql_database_instance" "replica" {
 
         name  = lookup(database_flags.value, "name", null)
         value = lookup(database_flags.value, "value", null)
+      }
+    }
+
+    dynamic "insights_config" {
+      for_each = var.enable_insights_config_on_replica ? range(1) : []
+      content {
+        query_insights_enabled  = true
+        query_string_length     = 1024
+        record_application_tags = true
+        record_client_address   = true
       }
     }
 

--- a/google_cloudsql_postgres/variables.tf
+++ b/google_cloudsql_postgres/variables.tf
@@ -3,15 +3,33 @@
 # for argument reference for 'sql_database_instance' resource.
 #
 
-variable "project_id" {
-  type    = string
-  default = null
+variable "application" {
+  description = "Application e.g., bouncer."
+  type        = string
+}
+
+variable "authorized_networks" {
+  default     = []
+  description = "A list of authorized_network maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html"
+  type        = list(any)
+}
+
+variable "availability_type" {
+  default     = "REGIONAL"
+  description = "high availability (REGIONAL) or single zone (ZONAL)"
+  type        = string
+}
+
+variable "component" {
+  default     = "db"
+  description = "A logical component of an application"
+  type        = string
 }
 
 variable "connector_enforcement" {
-  type        = string
   default     = null
   description = "Enables the enforcement of Cloud SQL Auth Proxy or Cloud SQL connectors for all the connections. If enabled, all the direct connections are rejected."
+  type        = string
 
   validation {
     condition     = var.connector_enforcement == null ? true : contains(["NOT_REQUIRED", "REQUIRED"], var.connector_enforcement)
@@ -19,102 +37,99 @@ variable "connector_enforcement" {
   }
 }
 
-
 variable "custom_database_name" {
   default     = ""
   description = "Use this field for custom database name."
+  type        = string
 }
 
-variable "application" {
-  description = "Application e.g., bouncer."
+variable "custom_replica_name" {
+  default     = ""
+  description = "Custom database replica name."
+  type        = string
 }
 
 variable "data_cache_enabled" {
-  type        = bool
   default     = true
   description = "Whether data cache is enabled for the instance. Only available for `ENTERPRISE_PLUS` edition instances."
+  type        = bool
 }
 
-variable "environment" {
-  description = "Environment e.g., stage."
+variable "database_flags" {
+  default     = []
+  description = "A list of database flag maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html"
+  type        = list(any)
 }
 
-variable "edition" {
+variable "database_version" {
+  default     = "POSTGRES_13"
+  description = "Postgres version e.g., POSTGRES_13"
   type        = string
-  default     = "ENTERPRISE"
-  description = "The edition of the instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`."
 }
 
-variable "component" {
-  description = "A logical component of an application"
-  default     = "db"
+variable "db_cpu" {
+  default     = "2"
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  type        = string
 }
 
-variable "realm" {
-  description = "Realm e.g., nonprod."
+variable "db_mem_gb" {
+  default     = "12"
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  type        = string
 }
 
 variable "deletion_protection" {
   default     = true
-  type        = bool
   description = "Whether the instance is protected from deletion (TF)"
+  type        = bool
 }
 
 variable "deletion_protection_enabled" {
   default     = true
-  type        = bool
   description = "Whether the instance is protected from deletion (API)"
+  type        = bool
 }
 
-variable "instance_version" {
-  default     = "v1"
-  description = "Version of database. Use this field if you need to spin up a new database instance."
+variable "edition" {
+  default     = "ENTERPRISE"
+  description = "The edition of the instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`."
+  type        = string
 }
 
-variable "region" {
-  description = "Region where database should be provisioned."
-  default     = "us-west1"
+variable "enable_insights_config_on_replica" {
+  default     = false
+  description = "If true, will allow enable insights config on replica"
+  type        = bool
 }
 
-variable "database_version" {
-  default = "POSTGRES_13"
-}
-
-variable "replica_count" {
-  default = 0
-}
-
-variable "db_cpu" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
-  default     = "2"
-}
-
-variable "db_mem_gb" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
-  default     = "12"
-}
-
-variable "tier_override" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.db_cpu and var.db_mem_gb"
-  default     = ""
-}
-
-variable "availability_type" {
-  description = "high availability (REGIONAL) or single zone (ZONAL)"
-  default     = "REGIONAL"
-}
-
-variable "authorized_networks" {
-  default = []
+variable "enable_private_path_for_google_cloud_services" {
+  default     = false
+  description = "If true, will allow Google Cloud Services access over private IP."
+  type        = bool
 }
 
 variable "enable_public_ip" {
   default     = false
   description = "If true, will assign a public IP to database instance."
+  type        = bool
+}
+
+variable "environment" {
+  description = "Environment e.g., stage."
+  type        = string
+}
+
+variable "instance_version" {
+  default     = "v1"
+  description = "Version of database. Use this field if you need to spin up a new database instance."
+  type        = string
 }
 
 variable "ip_configuration_ssl_mode" {
-  default = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+  default     = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+  description = "Specify how SSL connection should be enforced in DB connections. Supported values are ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY, and TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+  type        = string
   validation {
     condition     = contains(["ALLOW_UNENCRYPTED_AND_ENCRYPTED", "ENCRYPTED_ONLY", "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"], var.ip_configuration_ssl_mode)
     error_message = "The ip_configuration_ssl_mode value must be one of ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY, or TRUSTED_CLIENT_CERTIFICATE_REQUIRED. Also ensure that ip_configuration_require_ssl value matches this variable."
@@ -123,94 +138,133 @@ variable "ip_configuration_ssl_mode" {
 
 variable "maintenance_window_day" {
   # Monday
-  default = 1
+  default     = 1
+  description = "Maintenance window day"
+  type        = number
 }
 
 variable "maintenance_window_hour" {
   # UTC hour
-  default = 17
+  default     = 17
+  description = "Maintenance window hour"
+  type        = number
 }
 
 variable "maintenance_window_update_track" {
-  default = "stable"
+  default     = "stable"
+  description = "Receive updates after one week (canary) or after two weeks (stable) or after five weeks (week5) of notification."
+  type        = string
 }
 
 variable "network" {
-  description = "Network where the private peering should attach."
   default     = "default"
-}
-
-variable "database_flags" {
-  description = "A list of database flag maps: https://www.terraform.io/docs/providers/google/r/sql_database_instance.html"
-  default     = []
-}
-
-variable "password_validation_policy_enable" {
-  description = "Enable password validation policy"
-  default     = false
-}
-
-variable "password_validation_policy_min_length" {
-  description = "Min length for password"
-  default     = 0
+  description = "Network where the private peering should attach."
+  type        = string
 }
 
 variable "password_validation_policy_complexity" {
-  description = "Require complex password, must contain an uppercase letter, lowercase letter, number, and symbol"
   default     = false
-}
-
-variable "password_validation_policy_reuse_interval" {
-  description = "Specifies the number of previous passwords that can't be reused"
-  default     = 0
+  description = "Require complex password, must contain an uppercase letter, lowercase letter, number, and symbol"
+  type        = bool
 }
 
 variable "password_validation_policy_disallow_username_substring" {
-  description = "Prevents the use of the username in the password"
   default     = false
+  description = "Prevents the use of the username in the password"
+  type        = bool
+}
+
+variable "password_validation_policy_enable" {
+  default     = false
+  description = "Enable password validation policy"
+  type        = bool
+}
+
+variable "password_validation_policy_min_length" {
+  default     = 0
+  description = "Min length for password"
+  type        = number
 }
 
 variable "password_validation_policy_password_change_interval" {
-  description = "Specifies the minimum duration after which you can change the password in hours"
   default     = "0s"
+  description = "Specifies the minimum duration after which you can change the password in hours"
+  type        = string
 }
 
-variable "enable_private_path_for_google_cloud_services" {
-  default     = false
-  description = "If true, will allow Google Cloud Services access over private IP."
+variable "password_validation_policy_reuse_interval" {
+  default     = 0
+  description = "Specifies the number of previous passwords that can't be reused"
+  type        = number
 }
 
-variable "enable_insights_config_on_replica" {
-  default     = false
-  description = "If true, will allow enable insights config on replica"
+variable "project_id" {
+  default     = null
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "realm" {
+  description = "Realm e.g., nonprod."
+  type        = string
+}
+
+variable "region" {
+  default     = "us-west1"
+  description = "Region where database should be provisioned."
+  type        = string
 }
 
 variable "replica_availability_type" {
   default     = "ZONAL"
   description = "Allow setting availability configuration of replica"
+  type        = string
 }
 
-variable "custom_replica_name" {
-  default     = ""
-  description = "Custom database replica name."
+variable "replica_count" {
+  default     = 0
+  description = "Number of instances"
+  type        = number
+}
+
+variable "replica_data_cache_enabled" {
+  default     = true
+  description = "Whether data cache is enabled for the replica instance. Only available for `ENTERPRISE_PLUS` edition instances."
+  type        = bool
 }
 
 variable "replica_db_cpu" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
   default     = "2"
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  type        = string
 }
 
 variable "replica_db_mem_gb" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
   default     = "12"
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing"
+  type        = string
 }
 
-variable "replica_tier_override" {
-  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica_db_cpu and var.replica_db_mem_gb"
-  default     = null
+variable "replica_edition" {
+  default     = "ENTERPRISE"
+  description = "The edition of the replica instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`."
+  type        = string
 }
 
 variable "replica_region_override" {
-  description = "This OVERRIDES var.region for replicas (replicas use var.region per default)."
   default     = null
+  description = "This OVERRIDES var.region for replicas (replicas use var.region per default)."
+  type        = string
+}
+
+variable "replica_tier_override" {
+  default     = null
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.replica_db_cpu and var.replica_db_mem_gb"
+  type        = string
+}
+
+variable "tier_override" {
+  default     = ""
+  description = "See: https://cloud.google.com/sql/pricing#2nd-gen-pricing. This OVERRIDES var.db_cpu and var.db_mem_gb"
+  type        = string
 }


### PR DESCRIPTION
This implements the postgres equivalent of https://github.com/mozilla/terraform-modules/pull/291 & https://github.com/mozilla/terraform-modules/pull/295
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
This allows users to enable Cloud SQL Enterprise Plus on replica instances. To configure this, set `replica_edition = "ENTERPRISE_PLUS"` in upstream modules.

I also alphabetized variables.tf to make it easier to find things and explicitly defined types for each variable to get rid of warnings in IDEs.
```
