### PR TITLE
fix(google_gke_namespace_logging): Allow passing empty string as service account

### DIFF
--- a/google_gke_namespace_logging/main.tf
+++ b/google_gke_namespace_logging/main.tf
@@ -23,12 +23,9 @@ resource "google_logging_project_bucket_config" "namespace" {
   enable_analytics = true
 }
 
-moved {
-  from = google_project_iam_member.logging_bucket_writer[0]
-  to   = google_project_iam_member.logging_bucket_writer
-}
-
 resource "google_project_iam_member" "logging_bucket_writer" {
+  count = var.logging_writer_service_account_member != "" ? 1 : 0
+
   project = var.project
   role    = "roles/logging.bucketWriter"
   member  = var.logging_writer_service_account_member
@@ -55,12 +52,9 @@ resource "google_bigquery_dataset" "namespace" {
   location                        = "US"
 }
 
-moved {
-  from = google_bigquery_dataset_iam_member.logging_dataset_writer[0]
-  to   = google_bigquery_dataset_iam_member.logging_dataset_writer
-}
-
 resource "google_bigquery_dataset_iam_member" "logging_dataset_writer" {
+  count = var.logging_writer_service_account_member != "" ? 1 : 0
+
   dataset_id = google_bigquery_dataset.namespace.dataset_id
   role       = "roles/bigquery.dataEditor"
   member     = var.logging_writer_service_account_member


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/OPST-2378
Breakage from https://github.com/mozilla/terraform-modules/pull/292

Some tenants set `disable_shared_integrations: true` which prevents them from
creating a log sink with a unique service account. We should handle this case
by conditionally creating the IAM permissions if the service account is not ""

<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Allow passing empty string as service account
```
