### PR TITLE
fix:give backend_bucket_name_override a default value

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -151,7 +151,7 @@ jobs:
         persist-credentials: false
       # Do the per-module steps in a composite action because matrixes can't handle dynamic outputs
     - name: Generate docs and version bump
-      uses: mozilla/terraform-modules/.github/actions@9e2a7b33aa1cd31edd53283f467b2a17a36ad2e9 #main
+      uses: mozilla/terraform-modules/.github/actions@51e6c2f08e61bd9b80cb3d36f428e89b23ddb053 #main
       with:
         package-name: ${{ matrix.directory }}
         changelog-entry: ${{ steps.changelog.outputs.result }}

--- a/google_cdn-external/README.md
+++ b/google_cdn-external/README.md
@@ -7,7 +7,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_addresses"></a> [addresses](#input\_addresses) | IP Addresses. | <pre>object({<br/>    ipv4 = string,<br/>    ipv6 = string,<br/>  })</pre> | n/a | yes |
 | <a name="input_application"></a> [application](#input\_application) | Application name. | `string` | n/a | yes |
-| <a name="input_backend_bucket_name_override"></a> [backend\_bucket\_name\_override](#input\_backend\_bucket\_name\_override) | Force a particular name for CDN backend bucket. Should only be used for legacy infra. | `string` | n/a | yes |
+| <a name="input_backend_bucket_name_override"></a> [backend\_bucket\_name\_override](#input\_backend\_bucket\_name\_override) | Force a particular name for CDN backend bucket. Should only be used for legacy infra. | `string` | `""` | no |
 | <a name="input_backend_timeout_sec"></a> [backend\_timeout\_sec](#input\_backend\_timeout\_sec) | Timeout for backend service. | `number` | `10` | no |
 | <a name="input_backend_type"></a> [backend\_type](#input\_backend\_type) | Backend type to create. Must be set to one of [service, bucket, service\_and\_bucket]. When service\_and\_bucket, the default backend is the service | `string` | `"service"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of GCS bucket to use as CDN backend. Required if backend\_type is set to 'bucket' or 'service\_and\_bucket'. | `string` | `""` | no |

--- a/google_cdn-external/variables.tf
+++ b/google_cdn-external/variables.tf
@@ -143,5 +143,6 @@ variable "bucket_name" {
 
 variable "backend_bucket_name_override" {
   type        = string
+  default     = ""
   description = "Force a particular name for CDN backend bucket. Should only be used for legacy infra."
 }


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Give backend_bucket_name_override a default value to prevent errors if it's not provided
```
