### PR TITLE
fix:update substitution to strictly grab last 5 chars

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -39,7 +39,7 @@ runs:
           exit 0
         fi
 
-        TAG_VERSION="${TAG#*-}"
+        TAG_VERSION="${TAG: -5}"
         echo "TAG_VERSION = $TAG_VERSION"
         SEMVER_REGEX="^[0-9].[0-9].[0-9]$"
         if [[ $TAG_VERSION =~ $SEMVER_REGEX ]] ; then


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Change tag extraction bash to strictly grab the last 5 characters of the tag, instead of assuming the version is after the first dash. Fixes versioning CI for modules that have `-`s in them.
```
Fixes google_cdn-external builds - https://github.com/mozilla/terraform-modules/actions/runs/14646386623/job/41101547611?pr=299