### PR TITLE
Google certificate manager certificate map/update

### DIFF
--- a/google_certificate_manager_certificate_map/README.md
+++ b/google_certificate_manager_certificate_map/README.md
@@ -10,11 +10,12 @@
 | <a name="input_custom_name_prefix"></a> [custom\_name\_prefix](#input\_custom\_name\_prefix) | use this to set a custom name\_prefix for resource names | `string` | `""` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `string` | n/a | yes |
 | <a name="input_realm"></a> [realm](#input\_realm) | n/a | `string` | n/a | yes |
-| <a name="input_shared_infra_project_id"></a> [shared\_infra\_project\_id](#input\_shared\_infra\_project\_id) | id of shared infra project to create resources in | `string` | n/a | yes |
+| <a name="input_shared_infra_project_id"></a> [shared\_infra\_project\_id](#input\_shared\_infra\_project\_id) | id of shared infra project to create resources in | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_certificate_map"></a> [certificate\_map](#output\_certificate\_map) | n/a |
 | <a name="output_dns_authorizations"></a> [dns\_authorizations](#output\_dns\_authorizations) | n/a |
 <!-- END_TF_DOCS -->

--- a/google_certificate_manager_certificate_map/certificate-map.tf
+++ b/google_certificate_manager_certificate_map/certificate-map.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 resource "google_certificate_manager_certificate_map" "default" {
-  project     = var.shared_infra_project_id
+  project     = coalesce(var.shared_infra_project_id, data.google_project.project.project_id)
   name        = format("%s", local.name_prefix)
   description = "managed by terraform"
 }
@@ -27,7 +27,7 @@ resource "random_id" "certificate_map_entry_id" {
 resource "google_certificate_manager_certificate_map_entry" "default" {
   for_each = local.certificate_map_entries_map
 
-  project     = var.shared_infra_project_id
+  project     = coalesce(var.shared_infra_project_id, data.google_project.project.project_id)
   name        = format("%s-%s", local.name_prefix, random_id.certificate_map_entry_id[each.key].hex)
   description = "managed by terraform"
 

--- a/google_certificate_manager_certificate_map/certificates.tf
+++ b/google_certificate_manager_certificate_map/certificates.tf
@@ -1,7 +1,7 @@
 resource "google_certificate_manager_dns_authorization" "default" {
   for_each = { for cert in var.certificates : replace(cert.hostname, ".", "-") => cert if cert.dns_authorization == true }
 
-  project     = var.shared_infra_project_id
+  project     = coalesce(var.shared_infra_project_id, data.google_project.project.project_id)
   name        = format("%s", each.key)
   description = "managed by terraform"
 
@@ -11,7 +11,7 @@ resource "google_certificate_manager_dns_authorization" "default" {
 resource "google_certificate_manager_certificate" "default" {
   for_each = { for cert in var.certificates : replace(cert.hostname, ".", "-") => cert }
 
-  project     = var.shared_infra_project_id
+  project     = coalesce(var.shared_infra_project_id, data.google_project.project.project_id)
   name        = format("%s", each.key)
   description = "managed by terraform"
 

--- a/google_certificate_manager_certificate_map/data.tf
+++ b/google_certificate_manager_certificate_map/data.tf
@@ -1,0 +1,1 @@
+data "google_project" "project" {}

--- a/google_certificate_manager_certificate_map/outputs.tf
+++ b/google_certificate_manager_certificate_map/outputs.tf
@@ -1,3 +1,7 @@
+output "certificate_map" {
+  value = google_certificate_manager_certificate_map.default
+}
+
 output "dns_authorizations" {
   value = flatten([for a in google_certificate_manager_dns_authorization.default : a.dns_resource_record])
 }

--- a/google_certificate_manager_certificate_map/variables.tf
+++ b/google_certificate_manager_certificate_map/variables.tf
@@ -19,6 +19,7 @@ variable "environment" {
 variable "shared_infra_project_id" {
   description = "id of shared infra project to create resources in"
   type        = string
+  default = ""
 }
 
 variable "certificates" {


### PR DESCRIPTION
## Changelog entry
```
* add `certificate_manager_ceritifcate_map` resource to outputs to make it's attributes readable by module users
* make `shared_infra_project_id` optional and use the provider project to build certmaps by default
```
