### PR TITLE
feat(google_gke): add config_connector_config block to GKE cluster resource, disabled by default

### DIFF
--- a/google_gke/README.md
+++ b/google_gke/README.md
@@ -155,6 +155,7 @@ module "gke" {
 | <a name="input_description"></a> [description](#input\_description) | The description of the cluster | `string` | `null` | no |
 | <a name="input_disable_snat_status"></a> [disable\_snat\_status](#input\_disable\_snat\_status) | Whether the cluster disables default in-node sNAT rules. Defaults to false. | `bool` | `false` | no |
 | <a name="input_dns_cache"></a> [dns\_cache](#input\_dns\_cache) | The status of the NodeLocal DNSCache addon. | `bool` | `true` | no |
+| <a name="input_enable_config_connector"></a> [enable\_config\_connector](#input\_enable\_config\_connector) | Enable Config Connector Add-On | `bool` | `false` | no |
 | <a name="input_enable_cost_allocation"></a> [enable\_cost\_allocation](#input\_enable\_cost\_allocation) | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | <a name="input_enable_dataplane"></a> [enable\_dataplane](#input\_enable\_dataplane) | Whether to enable dataplane v2 on the cluster. Sets DataPath field. Defaults to false. | `bool` | `false` | no |
 | <a name="input_enable_dns_endpoint"></a> [enable\_dns\_endpoint](#input\_enable\_dns\_endpoint) | Enable external DNS endpoint for control plane access | `bool` | `false` | no |

--- a/google_gke/cluster.tf
+++ b/google_gke/cluster.tf
@@ -161,6 +161,10 @@ resource "google_container_cluster" "primary" {
       enabled = var.fuse_csi_driver
     }
 
+    config_connector_config {
+      enabled = var.enable_config_connector
+    }
+
     dns_cache_config {
       enabled = var.dns_cache
     }

--- a/google_gke/variables.tf
+++ b/google_gke/variables.tf
@@ -7,6 +7,12 @@ variable "description" {
   type        = string
 }
 
+variable "enable_config_connector" {
+  default     = false
+  description = "Enable Config Connector Add-On"
+  type        = bool
+}
+
 variable "enable_dns_endpoint" {
   default     = false
   description = "Enable external DNS endpoint for control plane access"


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Add configuration to enable Google Config Connector, left disabled by default.
```
https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall
