### PR TITLE
feat(fastly): Add staging toggle

### DIFF
--- a/google_fastly_waf/.terraform-docs.yaml
+++ b/google_fastly_waf/.terraform-docs.yaml
@@ -6,6 +6,7 @@ content: |-
   ```hcl
   {{ include "examples/example.tf" }}
   {{ include "examples/example_maintenance_page.tf" }}
+  {{ include "examples/example_stage.tf" }}
   ```
 
   {{ .Inputs }}

--- a/google_fastly_waf/README.md
+++ b/google_fastly_waf/README.md
@@ -97,6 +97,43 @@ EOF
     },
   ]
 }
+# Fastly supports deploying your VCL to a "staging" environment. This environment
+# has a different IP that requires you to override your local `/etc/hosts` to test
+# https://docs.fastly.com/products/staging
+# 
+# The workflow to deploy stage would be to add the `stage = true` arguement for
+# the module, verify your changes look correct, then remove (or comment out) the
+# `stage` argument and apply again. This will promote your changes to production.
+module "fastly_stage" {
+  source      = "github.com/mozilla/terraform-modules//google_fastly_waf?ref=main"
+  application = glab
+  environment = foo
+  project_id  = bar
+  realm       = bar
+
+  waf_enabled       = true
+  ngwaf_agent_level = "block"
+  stage             = true
+
+  subscription_domains = [
+    { name = "my-app.mozilla.org" }
+  ]
+
+  domains = [
+    { name = "my-cool-app.global.ssl.fastly.net" },
+  ]
+
+  backends = [
+    {
+      address           = "my_cool_app.net"
+      name              = "my_cool_app_net"
+      port              = 443
+      ssl_cert_hostname = "my_cool_app.net"
+      ssl_sni_hostname  = "my_cool_app.net"
+      use_ssl           = true
+    },
+  ]
+}
 ```
 
 ## Inputs
@@ -114,6 +151,7 @@ EOF
 | <a name="input_realm"></a> [realm](#input\_realm) | The realm this module is deployed into | `string` | n/a | yes |
 | <a name="input_response_objects"></a> [response\_objects](#input\_response\_objects) | List of synthetic response objects to attach to the Fastly service. | <pre>list(object({<br/>    name              = string           # required<br/>    status            = optional(number) # e.g. 503<br/>    response          = optional(string) # e.g. "Ok"<br/>    content           = optional(string)<br/>    content_type      = optional(string)<br/>    request_condition = optional(string) # name of an existing REQUEST condition<br/>    cache_condition   = optional(string) # name of an existing CACHE   condition<br/>  }))</pre> | `[]` | no |
 | <a name="input_snippets"></a> [snippets](#input\_snippets) | snippets | `list(any)` | `[]` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Determine if something should be deployed to stage | `bool` | `false` | no |
 | <a name="input_subscription_domains"></a> [subscription\_domains](#input\_subscription\_domains) | Domains to issue SSL certificates for | `list(any)` | `[]` | no |
 
 ## Outputs

--- a/google_fastly_waf/examples/example_stage.tf
+++ b/google_fastly_waf/examples/example_stage.tf
@@ -1,0 +1,37 @@
+# Fastly supports deploying your VCL to a "staging" environment. This environment
+# has a different IP that requires you to override your local `/etc/hosts` to test
+# https://docs.fastly.com/products/staging
+#
+# The workflow to deploy stage would be to add the `stage = true` arguement for
+# the module, verify your changes look correct, then remove (or comment out) the
+# `stage` argument and apply again. This will promote your changes to production.
+module "fastly_stage" {
+  source      = "github.com/mozilla/terraform-modules//google_fastly_waf?ref=main"
+  application = glab
+  environment = foo
+  project_id  = bar
+  realm       = bar
+
+  waf_enabled       = true
+  ngwaf_agent_level = "block"
+  stage             = true
+
+  subscription_domains = [
+    { name = "my-app.mozilla.org" }
+  ]
+
+  domains = [
+    { name = "my-cool-app.global.ssl.fastly.net" },
+  ]
+
+  backends = [
+    {
+      address           = "my_cool_app.net"
+      name              = "my_cool_app_net"
+      port              = 443
+      ssl_cert_hostname = "my_cool_app.net"
+      ssl_sni_hostname  = "my_cool_app.net"
+      use_ssl           = true
+    },
+  ]
+}

--- a/google_fastly_waf/locals.tf
+++ b/google_fastly_waf/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  waf_bypass_snippet = {
+    content  = "set req.http.x-sigsci-no-inspection = \"debug_bypass\";"
+    name     = "bypass_ngwaf"
+    type     = "recv"
+    priority = 1
+  }
+  snippets = concat(var.snippets, var.stage ? [local.waf_bypass_snippet] : [])
+}

--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -5,6 +5,12 @@ locals {
 resource "fastly_service_vcl" "default" {
   name = "${var.application}-${var.realm}-${var.environment}"
 
+  # Toggling staging environment deployment
+  # these variables work together and in inverse. I don't see a need
+  # to have a separate `activate` toggle right now
+  activate = !var.stage
+  stage    = var.stage
+
   product_enablement {
     brotli_compression = true
     bot_management     = true
@@ -77,7 +83,7 @@ resource "fastly_service_vcl" "default" {
 
   # Allow passing in arbitrary snippets for VCL configuration
   dynamic "snippet" {
-    for_each = var.snippets
+    for_each = local.snippets
     content {
       content  = snippet.value.content
       name     = snippet.value.name

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -67,6 +67,12 @@ variable "response_objects" {
   default = []
 }
 
+variable "stage" {
+  description = "Determine if something should be deployed to stage"
+  type        = bool
+  default     = false
+}
+
 ## NGWAF
 variable "ngwaf_agent_level" {
   type        = string


### PR DESCRIPTION
## Changelog entry
```
This features allows a consumer of the module to first deploy their VCL to Fastly's Staging infrastructure. This infrastructure does not support the WAF so we add a snippet to the configuration to bypass the WAF in staging mode.
```
