### PR TITLE
feat(fastly): Allow setting percentage or bypass WAF by setting to 0

### DIFF
--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -259,7 +259,7 @@ resource "sigsci_edge_deployment_service" "ngwaf_edge_service_link" {
   fastly_sid      = fastly_service_vcl.default.id
 
   activate_version = true
-  percent_enabled  = 100
+  percent_enabled  = var.ngwaf_percent_enabled
 
   depends_on = [
     sigsci_edge_deployment.ngwaf_edge_site_service,

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -84,3 +84,8 @@ variable "ngwaf_immediate_block" {
   type    = bool
   default = true
 }
+
+variable "ngwaf_percent_enabled" {
+  type    = int
+  default = 100
+}


### PR DESCRIPTION
## Changelog entry
```

- Adds the `ngwaf_percent_enabled` variable which configures how much traffic to send to WAF. This allows use cases where we want to entirely bypass WAF.

```
