### PR TITLE
fix(Fastly): Use number instead of int

### DIFF
--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -86,6 +86,6 @@ variable "ngwaf_immediate_block" {
 }
 
 variable "ngwaf_percent_enabled" {
-  type    = int
+  type    = number
   default = 100
 }


### PR DESCRIPTION
## Changelog entry
```
Fix: Use number instead of int!
```
