### PR TITLE
feat(fastly): Allow setting service account name manually

### DIFF
--- a/google_fastly_waf/iam.tf
+++ b/google_fastly_waf/iam.tf
@@ -1,6 +1,6 @@
 resource "google_service_account" "log_uploader" {
   project      = var.project_id
-  account_id   = substr("${var.application}-${var.realm}-${var.environment}-fastly", 0, 28)
+  account_id   = var.service_account != null ? var.service_account : substr("${var.application}-${var.realm}-${var.environment}-fastly", 0, 28)
   display_name = "Fastly Service account for uploading logs"
 }
 

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -73,6 +73,11 @@ variable "stage" {
   default     = false
 }
 
+variable "service_account" {
+  type    = string
+  default = null
+}
+
 ## NGWAF
 variable "ngwaf_agent_level" {
   type        = string


### PR DESCRIPTION
## Changelog entry
```
* Allow setting service_account manually, default to existing behavior of generating.
```
