### PR TITLE
Added CloudSQL to use in SVCSE-3162

### DIFF
--- a/google_permissions/outputs.tf
+++ b/google_permissions/outputs.tf
@@ -17,6 +17,10 @@ locals {
   project_additional_roles = [
     "roles/automl.editor",
     "roles/cloudsql.admin",
+    "roles/cloudsql.client",
+    "roles/cloudsql.instanceUser",
+    "roles/cloudsql.studioUser",
+    "roles/cloudsql.viewer",
     "roles/cloudtranslate.editor",
     "roles/editor",
     "roles/monitoring.uptimeCheckConfigEditor",


### PR DESCRIPTION
Adding  cloudsql.client, cloudsql.instanceUser, cloudsql.studioUser, and cloudsql.viewer roles to `project_additional_roles`. This allows the added roles to be assigned on https://github.com/mozilla/webservices-infra/pull/6228. The terraform plan is currently failing because these roles did not previously exist.

## Changelog entry
```
Added the following roles to `project_additional_roles` :

- roles/cloudsql.client
- roles/cloudsql.instanceUser
- roles/cloudsql.studioUser
- roles/cloudsql.viewer

```
