### PR TITLE
Updated other_roles.tf to add project level permissions

### DIFF
--- a/google_permissions/other_roles.tf
+++ b/google_permissions/other_roles.tf
@@ -159,6 +159,62 @@ resource "google_project_iam_binding" "nonprod_developer_db_admin" {
   members = module.developers_workgroup.members
 }
 
+resource "google_project_iam_binding" "prod_developer_db_client" {
+  count   = contains(var.prod_roles, "roles/cloudsql.client") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
+  project = var.google_prod_project_id
+  role    = "roles/cloudsql.client"
+  members = module.developers_workgroup.members
+}
+
+resource "google_project_iam_binding" "nonprod_developer_db_client" {
+  count   = contains(var.nonprod_roles, "roles/cloudsql.client") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
+  project = var.google_nonprod_project_id
+  role    = "roles/cloudsql.client"
+  members = module.developers_workgroup.members
+}
+
+resource "google_project_iam_binding" "prod_developer_db_instanceUser" {
+  count   = contains(var.prod_roles, "roles/cloudsql.instanceUser") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
+  project = var.google_prod_project_id
+  role    = "roles/cloudsql.instanceUser"
+  members = module.developers_workgroup.members
+}
+
+resource "google_project_iam_binding" "nonprod_developer_db_instanceUser" {
+  count   = contains(var.nonprod_roles, "roles/cloudsql.instanceUser") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
+  project = var.google_nonprod_project_id
+  role    = "roles/cloudsql.instanceUser"
+  members = module.developers_workgroup.members
+}
+
+resource "google_project_iam_binding" "prod_developer_db_studioUser" {
+  count   = contains(var.prod_roles, "roles/cloudsql.studioUser") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
+  project = var.google_prod_project_id
+  role    = "roles/cloudsql.studioUser"
+  members = module.developers_workgroup.members
+}
+
+resource "google_project_iam_binding" "nonprod_developer_db_studioUser" {
+  count   = contains(var.nonprod_roles, "roles/cloudsql.studioUser") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
+  project = var.google_nonprod_project_id
+  role    = "roles/cloudsql.studioUser"
+  members = module.developers_workgroup.members
+}
+
+resource "google_project_iam_binding" "prod_developer_db_viewer" {
+  count   = contains(var.prod_roles, "roles/cloudsql.viewer") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
+  project = var.google_prod_project_id
+  role    = "roles/cloudsql.viewer"
+  members = module.developers_workgroup.members
+}
+
+resource "google_project_iam_binding" "nonprod_developer_db_viewer" {
+  count   = contains(var.nonprod_roles, "roles/cloudsql.viewer") && !var.admin_only && var.google_nonprod_project_id != "" ? 1 : 0
+  project = var.google_nonprod_project_id
+  role    = "roles/cloudsql.viewer"
+  members = module.developers_workgroup.members
+}
+
 resource "google_project_iam_binding" "prod_developer_monitoring_uptimecheckconfigeditor" {
   count   = contains(var.prod_roles, "roles/monitoring.uptimeCheckConfigEditor") && !var.admin_only && var.google_prod_project_id != "" ? 1 : 0
   project = var.google_prod_project_id

--- a/google_permissions/outputs.tf
+++ b/google_permissions/outputs.tf
@@ -32,7 +32,6 @@ locals {
     "roles/secretmanager.secretAccessor",
     "roles/secretmanager.admin",
     "roles/secretmanager.secretVersionAdder",
-    "roles/cloudsql.viewer",
     "roles/storage.objectUser",
     "roles/oauthconfig.editor"
   ]


### PR DESCRIPTION
Updating other_roles.tf. to include project level binding for the new cloudsql permissions being added.

## Changelog entry
```
Updating other_roles.tf. to include cloudsql.client, instanceUser, studioUser, and viewer roles.
Removed duplicate "roles/cloudsql.viewer" from project_additional_roles
```
