### PR TITLE
Adding read endpoint and read endpoint port to outputs

### DIFF
--- a/google_redis/README.md
+++ b/google_redis/README.md
@@ -56,6 +56,6 @@ module "redis" {
 | <a name="output_host"></a> [host](#output\_host) | n/a |
 | <a name="output_persistence_iam_identity"></a> [persistence\_iam\_identity](#output\_persistence\_iam\_identity) | n/a |
 | <a name="output_port"></a> [port](#output\_port) | n/a |
-| <a name="output_read_endpoint"></a> [port](#output\_read_endpoint) | n/a |
-| <a name="output_read_endpoint_port"></a> [port](#output\_read_endpoint_port) | n/a |
+| <a name="output_read_endpoint"></a> [read\_endpoint](#output\_read\_endpoint) | n/a |
+| <a name="output_read_endpoint_port"></a> [read\_endpoint\_port](#output\_read\_endpoint\_port) | n/a |
 <!-- END_TF_DOCS -->

--- a/google_redis/README.md
+++ b/google_redis/README.md
@@ -56,4 +56,6 @@ module "redis" {
 | <a name="output_host"></a> [host](#output\_host) | n/a |
 | <a name="output_persistence_iam_identity"></a> [persistence\_iam\_identity](#output\_persistence\_iam\_identity) | n/a |
 | <a name="output_port"></a> [port](#output\_port) | n/a |
+| <a name="output_read_endpoint"></a> [port](#output\_read_endpoint) | n/a |
+| <a name="output_read_endpoint_port"></a> [port](#output\_read_endpoint_port) | n/a |
 <!-- END_TF_DOCS -->

--- a/google_redis/outputs.tf
+++ b/google_redis/outputs.tf
@@ -13,3 +13,11 @@ output "port" {
 output "persistence_iam_identity" {
   value = google_redis_instance.main.persistence_iam_identity
 }
+
+output "read_endpoint" {
+  value = google_redis_instance.main.read_endpoint
+}
+
+output "read_endpoint_port" {
+  value = google_redis_instance.main.read_endpoint_port
+}


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Adding the read_endpoint and read_endpoint_port output variables. This is to be able to output read replica host and ports in tf configurations.
for users of the affected modules!
```
