### PR TITLE
Adding read_replicas_mode and replica_count variables

### DIFF
--- a/google_redis/README.md
+++ b/google_redis/README.md
@@ -41,12 +41,12 @@ module "redis" {
 | <a name="input_maintenance_window_hour"></a> [maintenance\_window\_hour](#input\_maintenance\_window\_hour) | The hour (from 0-23) when maintenance should start | `number` | `16` | no |
 | <a name="input_memory_size_gb"></a> [memory\_size\_gb](#input\_memory\_size\_gb) | Memory size in GiB | `number` | `1` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | `null` | no |
+| <a name="input_read_replicas_mode"></a> [read\_replicas\_mode](#input\_read\_replicas\_mode) | n/a | `string` | `"READ_REPLICAS_DISABLED"` | no |
 | <a name="input_realm"></a> [realm](#input\_realm) | Realm e.g., nonprod. | `string` | n/a | yes |
 | <a name="input_redis_configs"></a> [redis\_configs](#input\_redis\_configs) | Redis configs https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs | `map(string)` | n/a | yes |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | n/a | `string` | `"REDIS_7_0"` | no |
-| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | The number of replica nodes | `number` | `0` | yes |
-| <a name="input_read_replicas_mode"></a> [read\_replicas\_mode](#input\_read\_replicas\_mode) |  Read replicas mode for the instance | `string` | `"READ_REPLICAS_DISABLED"` | yes |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `string` | `null` | no |
+| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | n/a | `string` | `0` | no |
 | <a name="input_tier"></a> [tier](#input\_tier) | Service tier of the instance. Either BASIC or STANDARD\_HA | `string` | n/a | yes |
 | <a name="input_transit_encryption_mode"></a> [transit\_encryption\_mode](#input\_transit\_encryption\_mode) | Controls whether tls is enabled | `string` | `"DISABLED"` | no |
 

--- a/google_redis/README.md
+++ b/google_redis/README.md
@@ -44,6 +44,8 @@ module "redis" {
 | <a name="input_realm"></a> [realm](#input\_realm) | Realm e.g., nonprod. | `string` | n/a | yes |
 | <a name="input_redis_configs"></a> [redis\_configs](#input\_redis\_configs) | Redis configs https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs | `map(string)` | n/a | yes |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | n/a | `string` | `"REDIS_7_0"` | no |
+| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | The number of replica nodes | `number` | `0` | yes |
+| <a name="input_read_replicas_mode"></a> [read\_replicas\_mode](#input\_read\_replicas\_mode) |  Read replicas mode for the instance | `string` | `"READ_REPLICAS_DISABLED"` | yes |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `string` | `null` | no |
 | <a name="input_tier"></a> [tier](#input\_tier) | Service tier of the instance. Either BASIC or STANDARD\_HA | `string` | n/a | yes |
 | <a name="input_transit_encryption_mode"></a> [transit\_encryption\_mode](#input\_transit\_encryption\_mode) | Controls whether tls is enabled | `string` | `"DISABLED"` | no |

--- a/google_redis/main.tf
+++ b/google_redis/main.tf
@@ -24,6 +24,8 @@ resource "google_redis_instance" "main" {
   memory_size_gb          = var.memory_size_gb
   redis_configs           = local.redis_configs
   redis_version           = var.redis_version
+  replica_count           = var.replica_count
+  read_replicas_mode      = var.read_replicas_mode
   region                  = var.region
   tier                    = var.tier
   transit_encryption_mode = var.transit_encryption_mode

--- a/google_redis/variables.tf
+++ b/google_redis/variables.tf
@@ -51,6 +51,16 @@ variable "redis_version" {
   type    = string
 }
 
+variable "replica_count" {
+  default = 0
+  type    = string
+}
+
+variable "read_replicas_mode" {
+  default = "READ_REPLICAS_DISABLED"
+  type    = string
+} 
+
 variable "region" {
   default = null
   type    = string

--- a/google_redis/variables.tf
+++ b/google_redis/variables.tf
@@ -59,7 +59,7 @@ variable "replica_count" {
 variable "read_replicas_mode" {
   default = "READ_REPLICAS_DISABLED"
   type    = string
-} 
+}
 
 variable "region" {
   default = null


### PR DESCRIPTION
<!-- Describe your Pull Request here - anything within the ```s will end up in the changelog -->

## Changelog entry
```
Adding read_replicas_mode and replica_count variables. These were previously configured under redis_configs but now have to be configured directly in the module in redis 7_2.

for users of the affected modules!
```
