### PR TITLE
feat(aws_gke_oidc_role): Add role_path variable

### DIFF
--- a/aws_gke_oidc_role/main.tf
+++ b/aws_gke_oidc_role/main.tf
@@ -40,6 +40,7 @@ module "iam_assumable_role_for_oidc" {
   version                       = "~> v5.9"
   create_role                   = true
   role_name                     = var.role_name
+  role_path                     = var.role_path
   role_description              = "Role for ${var.gke_cluster_name}/${var.gke_namespace}/${var.gke_service_account} to assume"
   provider_url                  = replace(data.aws_iam_openid_connect_provider.gke_oidc.url, "https://", "")
   role_policy_arns              = var.iam_policy_arns

--- a/aws_gke_oidc_role/variables.tf
+++ b/aws_gke_oidc_role/variables.tf
@@ -10,6 +10,12 @@ variable "role_name" {
   type        = string
 }
 
+variable "role_path" {
+  default     = null
+  description = "Path of IAM role"
+  type        = string
+}
+
 variable "aws_region" {
   description = "AWS region"
   type        = string


### PR DESCRIPTION
## Description

This PR adds `role_path` as a variable to support AWS OIDC rollout

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* OPST-1704

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
