### PR TITLE
fix(google_fastly_waf): The priority of a snippet can't be a string.

### DIFF
--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -89,7 +89,7 @@ resource "fastly_service_vcl" "default" {
       content  = snippet.value.content
       name     = snippet.value.name
       type     = snippet.value.type
-      priority = lookup(snippet.value, "priority", "")
+      priority = lookup(snippet.value, "priority", null)
     }
   }
 


### PR DESCRIPTION
## Description

The empty string is an invalid value for the Fastly snippet priority, since it needs to be a number. By setting the default value to `null`, we pretend the priority isn't set at all, so the upstream default value of 100 is used.

## Related Tickets & Documents

This came up in https://github.com/mozilla/webservices-infra/pull/6761.