### PR TITLE
fix(google_permissions): Use developer workgroups for default admin entitlement

### DIFF
--- a/google_permissions/pam_entitlement.tf
+++ b/google_permissions/pam_entitlement.tf
@@ -43,7 +43,7 @@ locals {
   # Create the map with the hard-coded value and append the distinct principals
   entitlement_wg_map = var.app_code != "" ? merge(
     {
-      "default" : ["workgroup:${var.app_code}/developers"] # this the default value for the default system entitlement
+      "default" : var.developer_ids # this the default value for the default system entitlement
     },
     {
       for name, add_entitlement in try(local.additional_entitlements, []) : add_entitlement.key => add_entitlement.entitlement.principals


### PR DESCRIPTION
## Description

There are some tenants that do not use a workgroup named the same as the tenant.
These tenants use .globals.extra_attributes.workgroup to specify the workgroup
with permissions to operate the service.

This module assumed that the workgroup would always match the tenant.

This PR uses developer workgroups for the default admin entitlement.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* MZCLD-782
* https://github.com/mozilla/webservices-infra/pull/6855 PR where this bug was found

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
