### PR TITLE
feat(google_certificate_manager_certificate_map): Support DNS Authorizations for additional domains

### DIFF
--- a/google_certificate_manager_certificate_map/certificates.tf
+++ b/google_certificate_manager_certificate_map/certificates.tf
@@ -8,6 +8,20 @@ resource "google_certificate_manager_dns_authorization" "default" {
   domain = each.value.hostname
 }
 
+resource "google_certificate_manager_dns_authorization" "additional_domains" {
+  for_each = {
+    for additional_domain in flatten([
+      for cert in var.certificates : cert.additional_domains if cert.dns_authorization == true
+    ]) : replace(additional_domain, ".", "-") => additional_domain
+  }
+
+  project     = coalesce(var.shared_infra_project_id, data.google_project.project.project_id)
+  name        = format("%s", each.key)
+  description = "managed by terraform"
+
+  domain = each.value
+}
+
 resource "google_certificate_manager_certificate" "default" {
   for_each = { for cert in var.certificates : replace(cert.hostname, ".", "-") => cert }
 
@@ -16,7 +30,13 @@ resource "google_certificate_manager_certificate" "default" {
   description = "managed by terraform"
 
   managed {
-    domains            = concat([each.value.hostname], each.value.additional_domains)
-    dns_authorizations = each.value.dns_authorization == true ? [google_certificate_manager_dns_authorization.default[each.key].id] : []
+    domains = concat([each.value.hostname], each.value.additional_domains)
+    dns_authorizations = each.value.dns_authorization == true ? concat(
+      [google_certificate_manager_dns_authorization.default[each.key].id],
+      [
+        for additional_domain in each.value.additional_domains :
+        google_certificate_manager_dns_authorization.additional_domains[replace(additional_domain, ".", "-")].id
+      ]
+    ) : []
   }
 }

--- a/google_certificate_manager_certificate_map/outputs.tf
+++ b/google_certificate_manager_certificate_map/outputs.tf
@@ -5,3 +5,7 @@ output "certificate_map" {
 output "dns_authorizations" {
   value = flatten([for a in google_certificate_manager_dns_authorization.default : a.dns_resource_record])
 }
+
+output "dns_authorizations_additional_domains" {
+  value = { for a in google_certificate_manager_dns_authorization.additional_domains : a.name => a.dns_resource_record }
+}


### PR DESCRIPTION
## Description

I used this with:

* [the  dev-iam-nonprod-webservices-mozgcp-net certificate](https://console.cloud.google.com/security/ccm/certificates/details/global/name/dev-iam-nonprod-webservices-mozgcp-net?project=moz-fx-webservices-high-nonpro&inv=1&invt=Ab5OWw)
* [and in Terraform](https://github.com/mozilla/webservices-infra/pull/6860/commits/0546be8ec414d30e4f3e056d5ce8655b2b6b4326#diff-975d5010273347e1b081da5aced23419379aac1f171e13ac0e74d65b60179779R11), specifically [where I create the required CNAME records](https://github.com/mozilla/webservices-infra/pull/6860/commits/0546be8ec414d30e4f3e056d5ce8655b2b6b4326#diff-05ffa065a9c3bed4e117837d15fa477b36dbc52be190d5266dd70db6629ee050R1).

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* IAM-1735

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
