### PR TITLE
feat(fastly): Log Sampling

### DIFF
--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -1,5 +1,6 @@
 locals {
-  domains = setunion(var.domains, var.subscription_domains)
+  domains         = setunion(var.domains, var.subscription_domains)
+  log_sample_name = "log_sampling"
 }
 
 resource "fastly_service_vcl" "default" {
@@ -173,6 +174,12 @@ resource "fastly_service_vcl" "default" {
     type      = "REQUEST"
   }
 
+  condition {
+    name      = local.log_sample_name
+    statement = "randombool(${var.log_sampling_percent},100)"
+    type      = "RESPONSE"
+  }
+
   vcl {
     name = "main"
     content = templatefile("${path.module}/vcl/main.vcl.tftpl",
@@ -184,21 +191,23 @@ resource "fastly_service_vcl" "default" {
   default_ttl = 0
 
   logging_bigquery {
-    dataset      = google_bigquery_dataset.fastly.dataset_id
-    name         = "bigquery-default"
-    project_id   = var.project_id
-    table        = google_bigquery_table.fastly.table_id
-    account_name = google_service_account.log_uploader.account_id
-    format       = file("${path.module}/logging/bq_format.txt")
+    dataset            = google_bigquery_dataset.fastly.dataset_id
+    name               = "bigquery-default"
+    project_id         = var.project_id
+    table              = google_bigquery_table.fastly.table_id
+    account_name       = google_service_account.log_uploader.account_id
+    format             = file("${path.module}/logging/bq_format.txt")
+    response_condition = local.log_sample_name
   }
 
   logging_gcs {
-    bucket_name  = google_storage_bucket.fastly.name
-    name         = "gcs-default"
-    project_id   = var.project_id
-    account_name = google_service_account.log_uploader.account_id
-    gzip_level   = 9
-    period       = 300 # 5 minutes
+    bucket_name        = google_storage_bucket.fastly.name
+    name               = "gcs-default"
+    project_id         = var.project_id
+    account_name       = google_service_account.log_uploader.account_id
+    gzip_level         = 9
+    period             = 300 # 5 minutes
+    response_condition = local.log_sample_name
   }
 }
 

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -78,6 +78,11 @@ variable "service_account" {
   default = null
 }
 
+variable "log_sampling_percent" {
+  type    = string
+  default = "10"
+}
+
 ## NGWAF
 variable "ngwaf_agent_level" {
   type        = string


### PR DESCRIPTION
## Description

This creates a new condition with a `randombool` set to the percentage the application wants to sample logs. Defaulting this to something low like 10% but can be increased or decreased using Terraform.

This injects a randombool statement into vcl in the streaming log conditions for GCS and BigQuery

