### PR TITLE
feat(google_provider): Create Google provider wrapper that includes the default labels

### DIFF
--- a/google_provider/README.md
+++ b/google_provider/README.md
@@ -2,6 +2,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
 
 ## Providers

--- a/google_provider/README.md
+++ b/google_provider/README.md
@@ -1,0 +1,42 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_component_code"></a> [component\_code](#input\_component\_code) | The component code for this infrastructure | `string` | `"notset"` | no |
+| <a name="input_credentials"></a> [credentials](#input\_credentials) | Path to service account key file or JSON string | `string` | `null` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name | `string` | `null` | no |
+| <a name="input_env_code"></a> [env\_code](#input\_env\_code) | The environment code (e.g., dev, staging, prod) | `string` | `"notset"` | no |
+| <a name="input_impersonate_service_account"></a> [impersonate\_service\_account](#input\_impersonate\_service\_account) | Service account to impersonate | `string` | `null` | no |
+| <a name="input_override_current_tf_version"></a> [override\_current\_tf\_version](#input\_override\_current\_tf\_version) | Override the current Terraform version | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID | `string` | n/a | yes |
+| <a name="input_realm"></a> [realm](#input\_realm) | The realm (e.g., sandbox, production) | `string` | `"notset"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The default GCP region | `string` | `"us-central1"` | no |
+| <a name="input_system"></a> [system](#input\_system) | The system/application name | `string` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The default GCP zone | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_default_labels"></a> [default\_labels](#output\_default\_labels) | The computed default labels applied to all resources |
+| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | The configured GCP project ID |
+| <a name="output_region"></a> [region](#output\_region) | The configured GCP region |
+| <a name="output_zone"></a> [zone](#output\_zone) | The configured GCP zone |

--- a/google_provider/locals.tf
+++ b/google_provider/locals.tf
@@ -1,0 +1,15 @@
+locals {
+
+  final_labels = {
+    # System-level labels
+    domain         = var.domain # legacy "function"
+    system         = var.system # legacy "application"
+    component_code = var.component_code
+    realm          = var.realm
+    env_code       = var.env_code
+
+    # Metadata labels
+    managed_by   = "terraform"
+    created_date = formatdate("YYYY-MM-DD", timestamp())
+  }
+}

--- a/google_provider/main.tf
+++ b/google_provider/main.tf
@@ -1,13 +1,3 @@
-terraform {
-  required_providers {
-    google = {
-      source = "hashicorp/google"
-      # need to provide for an override here
-      version = "~> 6.0"
-    }
-  }
-}
-
 provider "google" {
   project     = var.project_id
   region      = var.region

--- a/google_provider/main.tf
+++ b/google_provider/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      # need to provide for an override here
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project     = var.project_id
+  region      = var.region
+  zone        = var.zone
+  credentials = var.credentials
+
+  # Configure service account impersonation if specified
+  impersonate_service_account = var.impersonate_service_account
+
+  # Apply the computed default labels to all resources
+  default_labels = local.final_labels
+}

--- a/google_provider/outputs.tf
+++ b/google_provider/outputs.tf
@@ -1,0 +1,22 @@
+# Provider configuration outputs
+output "project_id" {
+  description = "The configured GCP project ID"
+  value       = var.project_id
+}
+
+output "region" {
+  description = "The configured GCP region"
+  value       = var.region
+}
+
+output "zone" {
+  description = "The configured GCP zone"
+  value       = var.zone
+}
+
+# Label outputs
+output "default_labels" {
+  description = "The computed default labels applied to all resources"
+  value       = local.final_labels
+}
+

--- a/google_provider/variables.tf
+++ b/google_provider/variables.tf
@@ -1,0 +1,71 @@
+# Core provider configuration
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "The default GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "The default GCP zone"
+  type        = string
+  default     = null
+}
+
+# Application and environment configuration
+variable "domain" {
+  description = "The domain name"
+  type        = string
+  default     = null
+}
+
+variable "system" {
+  description = "The system/application name"
+  type        = string
+  default     = null
+}
+
+variable "component_code" {
+  description = "The component code for this infrastructure"
+  type        = string
+  default     = "notset"
+}
+
+variable "realm" {
+  description = "The realm (e.g., sandbox, production)"
+  type        = string
+  default     = "notset"
+}
+
+variable "env_code" {
+  description = "The environment code (e.g., dev, staging, prod)"
+  type        = string
+  default     = "notset"
+}
+
+# Provider credentials (optional - can use environment variables instead)
+variable "credentials" {
+  description = "Path to service account key file or JSON string"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "impersonate_service_account" {
+  description = "Service account to impersonate"
+  type        = string
+  default     = null
+}
+
+#
+# HOW BEST TO SUPPORT THIS?
+#
+variable "override_current_tf_version" {
+  description = "Override the current Terraform version"
+  type        = string
+  default     = null
+}

--- a/google_provider/versions.tf
+++ b/google_provider/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    google_beta = {
+    google = {
       source = "hashicorp/google"
       # need to provide for an override here
       version = "~> 6.0"

--- a/google_provider/versions.tf
+++ b/google_provider/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google_beta = {
-      source  = "hashicorp/google"
+      source = "hashicorp/google"
       # need to provide for an override here
       version = "~> 6.0"
     }

--- a/google_provider/versions.tf
+++ b/google_provider/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    google_beta = {
+      source  = "hashicorp/google"
+      # need to provide for an override here
+      version = "~> 6.0"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/google_provider_beta/README.md
+++ b/google_provider_beta/README.md
@@ -2,7 +2,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_google_beta"></a> [google\_beta](#requirement\_google\_beta) | ~> 6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 6.0 |
 
 ## Providers
 
@@ -25,12 +26,10 @@ No resources.
 | <a name="input_domain"></a> [domain](#input\_domain) | The domain name | `string` | `null` | no |
 | <a name="input_env_code"></a> [env\_code](#input\_env\_code) | The environment code (e.g., dev, staging, prod) | `string` | `"notset"` | no |
 | <a name="input_impersonate_service_account"></a> [impersonate\_service\_account](#input\_impersonate\_service\_account) | Service account to impersonate | `string` | `null` | no |
-| <a name="input_is_external"></a> [is\_external](#input\_is\_external) | Whether this component is external-facing | `bool` | `false` | no |
 | <a name="input_override_current_tf_version"></a> [override\_current\_tf\_version](#input\_override\_current\_tf\_version) | Override the current Terraform version | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID | `string` | n/a | yes |
 | <a name="input_realm"></a> [realm](#input\_realm) | The realm (e.g., sandbox, production) | `string` | `"notset"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The default GCP region | `string` | `"us-central1"` | no |
-| <a name="input_risk_level"></a> [risk\_level](#input\_risk\_level) | The risk level (alias for data\_risk\_level for backwards compatibility) | `string` | `null` | no |
 | <a name="input_system"></a> [system](#input\_system) | The system/application name | `string` | `null` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The default GCP zone | `string` | `null` | no |
 

--- a/google_provider_beta/README.md
+++ b/google_provider_beta/README.md
@@ -1,0 +1,44 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_google_beta"></a> [google\_beta](#requirement\_google\_beta) | ~> 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_component_code"></a> [component\_code](#input\_component\_code) | The component code for this infrastructure | `string` | `"notset"` | no |
+| <a name="input_credentials"></a> [credentials](#input\_credentials) | Path to service account key file or JSON string | `string` | `null` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name | `string` | `null` | no |
+| <a name="input_env_code"></a> [env\_code](#input\_env\_code) | The environment code (e.g., dev, staging, prod) | `string` | `"notset"` | no |
+| <a name="input_impersonate_service_account"></a> [impersonate\_service\_account](#input\_impersonate\_service\_account) | Service account to impersonate | `string` | `null` | no |
+| <a name="input_is_external"></a> [is\_external](#input\_is\_external) | Whether this component is external-facing | `bool` | `false` | no |
+| <a name="input_override_current_tf_version"></a> [override\_current\_tf\_version](#input\_override\_current\_tf\_version) | Override the current Terraform version | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID | `string` | n/a | yes |
+| <a name="input_realm"></a> [realm](#input\_realm) | The realm (e.g., sandbox, production) | `string` | `"notset"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The default GCP region | `string` | `"us-central1"` | no |
+| <a name="input_risk_level"></a> [risk\_level](#input\_risk\_level) | The risk level (alias for data\_risk\_level for backwards compatibility) | `string` | `null` | no |
+| <a name="input_system"></a> [system](#input\_system) | The system/application name | `string` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The default GCP zone | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_default_labels"></a> [default\_labels](#output\_default\_labels) | The computed default labels applied to all resources |
+| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | The configured GCP project ID |
+| <a name="output_region"></a> [region](#output\_region) | The configured GCP region |
+| <a name="output_zone"></a> [zone](#output\_zone) | The configured GCP zone |

--- a/google_provider_beta/locals.tf
+++ b/google_provider_beta/locals.tf
@@ -7,8 +7,6 @@ locals {
     component_code = var.component_code
     realm          = var.realm
     env_code       = var.env_code
-    risk_level     = var.risk_level
-    is_external    = tostring(var.is_external)
 
     # Metadata labels
     managed_by   = "terraform"

--- a/google_provider_beta/locals.tf
+++ b/google_provider_beta/locals.tf
@@ -1,0 +1,17 @@
+locals {
+
+  final_labels = {
+    # System-level labels
+    domain         = var.domain # legacy "function"
+    system         = var.system # legacy "application"
+    component_code = var.component_code
+    realm          = var.realm
+    env_code       = var.env_code
+    risk_level     = var.risk_level
+    is_external    = tostring(var.is_external)
+
+    # Metadata labels
+    managed_by   = "terraform"
+    created_date = formatdate("YYYY-MM-DD", timestamp())
+  }
+}

--- a/google_provider_beta/main.tf
+++ b/google_provider_beta/main.tf
@@ -1,13 +1,3 @@
-terraform {
-  required_providers {
-    google_beta = {
-      source  = "hashicorp/google-beta"
-      # need to provide for an override here
-      version = "~> 6.0"
-    }
-  }
-}
-
 provider "google_beta" {
   project     = var.project_id
   region      = var.region

--- a/google_provider_beta/main.tf
+++ b/google_provider_beta/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    google_beta = {
+      source  = "hashicorp/google-beta"
+      # need to provide for an override here
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google_beta" {
+  project     = var.project_id
+  region      = var.region
+  zone        = var.zone
+  credentials = var.credentials
+
+  # Configure service account impersonation if specified
+  impersonate_service_account = var.impersonate_service_account
+
+  # Apply the computed default labels to all resources
+  default_labels = local.final_labels
+}

--- a/google_provider_beta/main.tf
+++ b/google_provider_beta/main.tf
@@ -1,4 +1,4 @@
-provider "google_beta" {
+provider "google-beta" {
   project     = var.project_id
   region      = var.region
   zone        = var.zone

--- a/google_provider_beta/outputs.tf
+++ b/google_provider_beta/outputs.tf
@@ -1,0 +1,22 @@
+# Provider configuration outputs
+output "project_id" {
+  description = "The configured GCP project ID"
+  value       = var.project_id
+}
+
+output "region" {
+  description = "The configured GCP region"
+  value       = var.region
+}
+
+output "zone" {
+  description = "The configured GCP zone"
+  value       = var.zone
+}
+
+# Label outputs
+output "default_labels" {
+  description = "The computed default labels applied to all resources"
+  value       = local.final_labels
+}
+

--- a/google_provider_beta/variables.tf
+++ b/google_provider_beta/variables.tf
@@ -1,0 +1,87 @@
+# Core provider configuration
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "The default GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "The default GCP zone"
+  type        = string
+  default     = null
+}
+
+# Application and environment configuration
+variable "domain" {
+  description = "The domain name"
+  type        = string
+  default     = null
+}
+
+variable "system" {
+  description = "The system/application name"
+  type        = string
+  default     = null
+}
+
+variable "component_code" {
+  description = "The component code for this infrastructure"
+  type        = string
+  default     = "notset"
+}
+
+variable "realm" {
+  description = "The realm (e.g., sandbox, production)"
+  type        = string
+  default     = "notset"
+}
+
+variable "env_code" {
+  description = "The environment code (e.g., dev, staging, prod)"
+  type        = string
+  default     = "notset"
+}
+
+variable "risk_level" {
+  description = "The risk level (alias for data_risk_level for backwards compatibility)"
+  type        = string
+  default     = null
+  validation {
+    condition     = var.risk_level == null || contains(["low", "medium", "high"], "high")
+    error_message = "Risk level must be one of: low, medium, high."
+  }
+}
+
+variable "is_external" {
+  description = "Whether this component is external-facing"
+  type        = bool
+  default     = false
+}
+
+# Provider credentials (optional - can use environment variables instead)
+variable "credentials" {
+  description = "Path to service account key file or JSON string"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "impersonate_service_account" {
+  description = "Service account to impersonate"
+  type        = string
+  default     = null
+}
+
+#
+# HOW BEST TO SUPPORT THIS?
+#
+variable "override_current_tf_version" {
+  description = "Override the current Terraform version"
+  type        = string
+  default     = null
+}

--- a/google_provider_beta/variables.tf
+++ b/google_provider_beta/variables.tf
@@ -47,22 +47,6 @@ variable "env_code" {
   default     = "notset"
 }
 
-variable "risk_level" {
-  description = "The risk level (alias for data_risk_level for backwards compatibility)"
-  type        = string
-  default     = null
-  validation {
-    condition     = var.risk_level == null || contains(["low", "medium", "high"], "high")
-    error_message = "Risk level must be one of: low, medium, high."
-  }
-}
-
-variable "is_external" {
-  description = "Whether this component is external-facing"
-  type        = bool
-  default     = false
-}
-
 # Provider credentials (optional - can use environment variables instead)
 variable "credentials" {
   description = "Path to service account key file or JSON string"

--- a/google_provider_beta/versions.tf
+++ b/google_provider_beta/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    google_beta = {
+      source  = "hashicorp/google-beta"
+      # need to provide for an override here
+      version = "~> 6.0"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/google_provider_beta/versions.tf
+++ b/google_provider_beta/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google_beta = {
-      source  = "hashicorp/google-beta"
+      source = "hashicorp/google-beta"
       # need to provide for an override here
       version = "~> 6.0"
     }

--- a/google_provider_beta/versions.tf
+++ b/google_provider_beta/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    google_beta = {
+    google-beta = {
       source = "hashicorp/google-beta"
       # need to provide for an override here
       version = "~> 6.0"


### PR DESCRIPTION
## Description

This PR adds a wrapper for both the google_provider and the google_provider_beta terraform providers.

This is to add our expected values to the default_labels variable supported by the providers. Additionally, this will allow us to centralize which version of the providers is currently supported.

## Related Tickets & Documents
* MZCLD-759
* MZCLD-906

