### PR TITLE
feat(fastly): Allow cache_setting blocks for Fastly serivces.

### DIFF
--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -121,6 +121,18 @@ resource "fastly_service_vcl" "default" {
     }
   }
 
+  dynamic "cache_setting" {
+    for_each = var.cache_settings
+    iterator = cs
+    content {
+      name            = cs.value.name
+      action          = try(cs.value.action, null)
+      cache_condition = try(cs.value.cache_condition, null)
+      stale_ttl       = try(cs.value.stale_ttl, null)
+      ttl             = try(cs.value.ttl, null)
+    }
+  }
+
   # https://www.fastly.com/documentation/solutions/tutorials/next-gen-waf-edge-integration/
   #### NGWAF Dynamic Snippets and dictionary - MANAGED BY FASTLY - Start
   dynamicsnippet {

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -67,6 +67,18 @@ variable "response_objects" {
   default = []
 }
 
+variable "cache_settings" {
+  description = "List of cache settings for the Fastly service."
+  type = list(object({
+    name            = string
+    action          = optional(string)
+    cache_condition = optional(string)
+    stale_ttl       = optional(number)
+    ttl             = optional(number)
+  }))
+  default = []
+}
+
 variable "stage" {
   description = "Determine if something should be deployed to stage"
   type        = bool


### PR DESCRIPTION
## Description

We'd like to override the Cloud Storage default TTL of one hour for Remote Settings attachments in Fastly, which requires adding a `cache_setting` block. This PR facilitates adding such blocks.

## Related Tickets & Documents

* [RMST-180](https://mozilla-hub.atlassian.net/browse/RMST-180)
