### PR TITLE
feat(google_project): allow specifying default bucket log retention

### DIFF
--- a/google_project/README.md
+++ b/google_project/README.md
@@ -15,6 +15,7 @@ Sets up a single GCP project linked to a billing account plus management metadat
 | <a name="input_display_name"></a> [display\_name](#input\_display\_name) | Display name for the project. Defaults to project\_name | `string` | `""` | no |
 | <a name="input_extra_project_labels"></a> [extra\_project\_labels](#input\_extra\_project\_labels) | Extra project labels (a map of key/value pairs) to be applied to the Project. | `map(string)` | `{}` | no |
 | <a name="input_log_analytics"></a> [log\_analytics](#input\_log\_analytics) | Enable log analytics for \_Default log bucket | `bool` | `false` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Log Retention in days. | `number` | `30` | no |
 | <a name="input_parent_id"></a> [parent\_id](#input\_parent\_id) | Parent folder (with GCP). | `string` | n/a | yes |
 | <a name="input_program_code"></a> [program\_code](#input\_program\_code) | Program Code of the project or resource: https://mana.mozilla.org/wiki/display/FINArchive/Program+Codes. Drop the `PC - `, lowercase the string and substitute spaces for dashes. | `string` | `"firefox-services"` | no |
 | <a name="input_program_name"></a> [program\_name](#input\_program\_name) | Name of the Firefox program being one of: ci, data, infrastructure, services, web. | `string` | `"services"` | no |

--- a/google_project/main.tf
+++ b/google_project/main.tf
@@ -76,6 +76,7 @@ resource "google_logging_project_bucket_config" "project" {
   location         = "global"
   bucket_id        = "_Default"
   enable_analytics = var.log_analytics
+  retention_days   = var.log_retention_days
   depends_on = [
     time_sleep.wait_10_seconds
   ]

--- a/google_project/variables.tf
+++ b/google_project/variables.tf
@@ -116,6 +116,12 @@ variable "log_analytics" {
   default     = false
 }
 
+variable "log_retention_days" {
+  type        = number
+  description = "Log Retention in days."
+  default     = 30
+}
+
 variable "deletion_policy" {
   default     = "PREVENT"
   description = "The deletion policy for the Project."


### PR DESCRIPTION
## Description

See https://mozilla-hub.atlassian.net/browse/MZCLD-1027. My plan is to keep the module default the [GCP default](https://github.com/mozilla/terraform-modules/pull/370) and set the actual default in the functional repos according to our retention policies.

## Related Tickets & Documents
* MZCLD-1027

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
