### PR TITLE
fix(ci): downgrade artifact download to 4.3.0

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -137,7 +137,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/download-artifact@v5.0.0
+      - uses: actions/download-artifact@v4.3.0
         with:
           path: outputs
       - name: Display structure of downloaded files


### PR DESCRIPTION
## Description
download-artifacts 5.0 has a breaking change w/r/t how it handles filepaths when dealing with multiple artifacts that breaks the comment & release portions of CI in this repo. This downgrade will unblock releases while I work on updating the workflows to handle this new behavior.

## Related Tickets & Documents
* Example of a PR with the broken comment - https://github.com/mozilla/terraform-modules/pull/370#issuecomment-3300271863
* Validated that the downgrade fixes commenting in https://github.com/mozilla/terraform-modules/pull/371
