### PR TITLE
fix(google_project): optimisitc pin to resolve conflicts

### DIFF
--- a/google_project/versions.tf
+++ b/google_project/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
 
     random = {


### PR DESCRIPTION
## Description
Convert google_project provider pin to optimistic to resolve version conflicts in downstream repos & bring it in-line with how the rest of the modules behave.

## Related Tickets & Documents
* downstream dependabot failing to resolve - https://github.com/mozilla/dataservices-infra/network/updates/1101270427