### PR TITLE
fix(fastly): Add application/geo+json mime type to compression list

### DIFF
--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -26,6 +26,7 @@ resource "fastly_service_vcl" "default" {
       "application/javascript",
       "text/javascript",
       "application/json",
+      "application/geo+json",
       "application/wasm",
       "application/vnd.ms-fontobject",
       "application/x-font-opentype",


### PR DESCRIPTION
## Description

We started seeing a failing health check in telescope, showing that `application/geo+json` was not being compressed in our CDN. Adding this mime type explicitly so it will be compressed going forward.

```sh
curl -I "https://firefox-settings-attachments.cdn.allizom.org/main-workspace/regions/ad99625f-7ec0-4fc4-a44d-07afe8f3ed91.geojson" -H "Accept-Encoding:br"
HTTP/2 200
content-type: application/geo+json
x-guploader-uploadid: AAwnv3KSMmmRRHzWMlyeHjxEp6r-7ZWqmJ_bI1V-fqy8rqPc9e1PN4_dXGpQJE_8hiR9EzwXQI8JK4o
expires: Mon, 22 Sep 2025 16:17:22 GMT
cache-control: public, max-age=3600
last-modified: Thu, 09 Mar 2023 14:08:02 GMT
etag: "daf1d4857d52bde47a293fbbe1fea035"
x-goog-generation: 1678370882119543
x-goog-metageneration: 1
x-goog-stored-content-encoding: identity
x-goog-stored-content-length: 1093343
x-goog-meta-goog-reserved-file-mtime: 1591622296
x-goog-hash: crc32c=mMCcVQ==
x-goog-hash: md5=2vHUhX1SveR6KT+74f6gNQ==
x-goog-storage-class: STANDARD
server: UploadServer
accept-ranges: bytes
age: 86
date: Mon, 22 Sep 2025 15:18:48 GMT
via: 1.1 varnish
x-served-by: cache-mad2200124-MAD
x-cache: HIT
x-cache-hits: 0
x-timer: S1758554328.407166,VS0,VE3
content-length: 1093343
```
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
