### PR TITLE
fix(google_fastly_waf): Allowing force domains update on TLS subscription

### DIFF
--- a/google_fastly_waf/certificate.tf
+++ b/google_fastly_waf/certificate.tf
@@ -2,4 +2,5 @@ resource "fastly_tls_subscription" "fastly" {
   count                 = length(var.subscription_domains) > 0 ? 1 : 0
   domains               = [for domain in var.subscription_domains : domain.name]
   certificate_authority = "lets-encrypt"
+  force_update          = var.subscription_domains_force_update
 }

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -53,6 +53,12 @@ variable "subscription_domains" {
   default     = []
 }
 
+variable "subscription_domains_force_update" {
+  default     = false
+  description = "Force update the subscription even if it has active domains. Warning: this can disable production traffic if used incorrectly."
+  type        = bool
+}
+
 variable "response_objects" {
   description = "List of synthetic response objects to attach to the Fastly service."
   type = list(object({


### PR DESCRIPTION
## Description
While working on the Bugzilla incident I had to update the domain list. Terraform wouldn't let me make changes to the certificate without setting this parameter, so I had to do it through the web console instead. This PR allows folks to make potentially unsafe domain changes through Terraform.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* INFRASEC-1228

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
