### PR TITLE
fix(monitor): Allow redis instance to be destroyed

### DIFF
--- a/google_redis/README.md
+++ b/google_redis/README.md
@@ -37,6 +37,7 @@ module "redis" {
 | <a name="input_custom_name"></a> [custom\_name](#input\_custom\_name) | Use this field to set a custom name for the redis instance | `string` | `""` | no |
 | <a name="input_enable_persistence"></a> [enable\_persistence](#input\_enable\_persistence) | Controls whether persistence features are enabled | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment e.g., stage. | `string` | n/a | yes |
+| <a name="input_lifecycle_prevent_destroy"></a> [lifecycle\_prevent\_destroy](#input\_lifecycle\_prevent\_destroy) | Prevents accidentally destroying the instance | `bool` | `true` | no |
 | <a name="input_maintenance_window_day"></a> [maintenance\_window\_day](#input\_maintenance\_window\_day) | Day of the week maintenance should occur | `string` | `"TUESDAY"` | no |
 | <a name="input_maintenance_window_hour"></a> [maintenance\_window\_hour](#input\_maintenance\_window\_hour) | The hour (from 0-23) when maintenance should start | `number` | `16` | no |
 | <a name="input_memory_size_gb"></a> [memory\_size\_gb](#input\_memory\_size\_gb) | Memory size in GiB | `number` | `1` | no |

--- a/google_redis/main.tf
+++ b/google_redis/main.tf
@@ -60,6 +60,6 @@ resource "google_redis_instance" "main" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = var.lifecycle_prevent_destroy
   }
 }

--- a/google_redis/variables.tf
+++ b/google_redis/variables.tf
@@ -104,3 +104,9 @@ variable "auth_enabled" {
   default     = false
   type        = bool
 }
+
+variable "lifecycle_prevent_destroy" {
+  description = "Prevents accidentally destroying the instance"
+  default     = true
+  type        = bool
+}


### PR DESCRIPTION
Allow setting `lifecycle.prevent_destroy` to false, so a redis instance can be destroyed.
~Also, fix typos and other issues found by `pre-commit`.~ - moved to PR #381 