### PR TITLE
fix(google_project): add wiz labels

### DIFF
--- a/google_project/README.md
+++ b/google_project/README.md
@@ -23,7 +23,8 @@ Sets up a single GCP project linked to a billing account plus management metadat
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of project e.g., autopush | `string` | n/a | yes |
 | <a name="input_project_services"></a> [project\_services](#input\_project\_services) | List of google\_project\_service APIs to enable. | `list(string)` | `[]` | no |
 | <a name="input_realm"></a> [realm](#input\_realm) | Realm is a grouping of environments being one of: global, nonprod, prod | `string` | `""` | no |
-| <a name="input_risk_level"></a> [risk\_level](#input\_risk\_level) | Level of risk the project poses, usually obtained from an RRA | `string` | `""` | no |
+| <a name="input_risk_level"></a> [risk\_level](#input\_risk\_level) | DEPRECATED - Level of risk the project poses, usually obtained from an RRA | `string` | `""` | no |
+| <a name="input_risk_profile"></a> [risk\_profile](#input\_risk\_profile) | Risk profile of the project, used by the Wiz security platform | <pre>object({<br/>    has_authentication    = string<br/>    has_exposed_api       = string<br/>    is_actively_developed = string<br/>    is_customer_facing    = string<br/>    is_internet_facing    = string<br/>    is_regulated          = string<br/>    regulatory_standards  = list(string)<br/>    sensitive_data_types  = list(string)<br/>    stores_data           = string<br/>  })</pre> | <pre>{<br/>  "has_authentication": "UNKNOWN",<br/>  "has_exposed_api": "UNKNOWN",<br/>  "is_actively_developed": "UNKNOWN",<br/>  "is_customer_facing": "UNKNOWN",<br/>  "is_internet_facing": "UNKNOWN",<br/>  "is_regulated": "UNKNOWN",<br/>  "regulatory_standards": [],<br/>  "sensitive_data_types": [],<br/>  "stores_data": "UNKNOWN"<br/>}</pre> | no |
 
 ## Outputs
 

--- a/google_project/locals.tf
+++ b/google_project/locals.tf
@@ -7,6 +7,22 @@ locals {
   app_code       = coalesce(var.app_code, var.project_name)
   component_code = coalesce(var.component_code, "${local.app_code}-uncat")
 
+  # Helper locals for truncation of risk profile lists to 63 characters
+  regulatory_standards_joined = join(",", var.risk_profile.regulatory_standards)
+  sensitive_data_types_joined = join(",", var.risk_profile.sensitive_data_types)
+
+  normalized_risk_profile = {
+    has_authentication    = upper(var.risk_profile.has_authentication)
+    has_exposed_api       = upper(var.risk_profile.has_exposed_api)
+    is_actively_developed = upper(var.risk_profile.is_actively_developed)
+    is_customer_facing    = upper(var.risk_profile.is_customer_facing)
+    is_internet_facing    = upper(var.risk_profile.is_internet_facing)
+    is_regulated          = upper(var.risk_profile.is_regulated)
+    stores_data           = upper(var.risk_profile.stores_data)
+    regulatory_standards  = length(local.regulatory_standards_joined) > 63 ? substr(local.regulatory_standards_joined, 0, 63) : local.regulatory_standards_joined
+    sensitive_data_types  = length(local.sensitive_data_types_joined) > 63 ? substr(local.sensitive_data_types_joined, 0, 63) : local.sensitive_data_types_joined
+  }
+
   default_project_labels = {
     app            = var.project_name
     app_code       = local.app_code
@@ -17,7 +33,7 @@ locals {
     realm          = var.realm
     risk_level     = var.risk_level
   }
-  all_project_labels = merge(local.default_project_labels, var.extra_project_labels)
+  all_project_labels = merge(local.default_project_labels, var.extra_project_labels, local.normalized_risk_profile)
 
   default_project_services = [
     "cloudasset.googleapis.com",
@@ -37,4 +53,19 @@ locals {
 
   default_data_access_logs = ["iam.googleapis.com", "secretmanager.googleapis.com", "sts.googleapis.com", "privilegedaccessmanager.googleapis.com"]
   data_access_logs_filter  = join("\n", toset([for v in concat(local.default_data_access_logs, var.additional_data_access_logs) : "AND NOT protoPayload.serviceName=\"${v}\""]))
+}
+
+# we want to emit a warning when we truncate the lists in the risk profile
+check "risk_profile_truncation" {
+  assert {
+    condition = length(local.regulatory_standards_joined) <= 63
+    error_message = "Warning: regulatory_standards list '${local.regulatory_standards_joined}' exceeds 63 characters and will be truncated to '${substr(local.regulatory_standards_joined, 0, 63)}'"
+  }
+}
+
+check "sensitive_data_truncation" {
+  assert {
+    condition = length(local.sensitive_data_types_joined) <= 63
+    error_message = "Warning: sensitive_data_types list '${local.sensitive_data_types_joined}' exceeds 63 characters and will be truncated to '${substr(local.sensitive_data_types_joined, 0, 63)}'"
+  }
 }

--- a/google_project/variables.tf
+++ b/google_project/variables.tf
@@ -63,8 +63,47 @@ variable "extra_project_labels" {
 
 variable "risk_level" {
   default     = ""
-  description = "Level of risk the project poses, usually obtained from an RRA"
+  description = "DEPRECATED - Level of risk the project poses, usually obtained from an RRA"
   type        = string
+}
+
+variable "risk_profile" {
+  description = "Risk profile of the project, used by the Wiz security platform"
+  type = object({
+    has_authentication    = string
+    has_exposed_api       = string
+    is_actively_developed = string
+    is_customer_facing    = string
+    is_internet_facing    = string
+    is_regulated          = string
+    regulatory_standards  = list(string)
+    sensitive_data_types  = list(string)
+    stores_data           = string
+  })
+
+  default = {
+    has_authentication    = "UNKNOWN"
+    has_exposed_api       = "UNKNOWN"
+    is_actively_developed = "UNKNOWN"
+    is_customer_facing    = "UNKNOWN"
+    is_internet_facing    = "UNKNOWN"
+    is_regulated          = "UNKNOWN"
+    regulatory_standards  = []
+    sensitive_data_types  = []
+    stores_data           = "UNKNOWN"
+  }
+
+  // need this so we use default values when not set or set to null
+  nullable = false
+
+  validation {
+    condition = alltrue([
+      for key, value in var.risk_profile :
+      key == "regulatory_standards" || key == "sensitive_data_types" ? true :
+      contains(["UNKNOWN", "YES", "NO"], upper(value))
+    ])
+    error_message = "String values must be one of: UNKNOWN, YES, NO. Lists (regulatory_standards, sensitive_data_types) can contain any strings."
+  }
 }
 
 #


### PR DESCRIPTION
## Description

Add the labels for the security tool Wiz. Labels are only added to the google_project resources.

- has_authentication - does the system require authentication?
- has_exposed_api - is an API publicly exposed?
- is_actively_developed - is this system currently under active development?
- is_customer_facing - is the system directly used by customers?
- is_internet_facing - is the system accessible from the public internet?
- is_regulated - does the system fall under any regulatory regime?
- regulatory_standards - list of applicable regulatory frameworks (e.g., GDPR, HIPAA).
- sensitive_data_types - types of sensitive data stored or processed (e.g., PII, PHI).
- stores_data - does the system store data (as opposed to stateless compute only)?


## Related Tickets & Documents
* MZCLD-1020

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
