### PR TITLE
chore(google_fastly_waf): update fastly provider min and max version

### DIFF
--- a/google_fastly_waf/versions.tf
+++ b/google_fastly_waf/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = ">= 5.10.0"
+      version = ">= 5.13.0, < 9.0.0"
     }
     sigsci = {
       source  = "signalsciences/sigsci"


### PR DESCRIPTION
## Description
* `atlantis plan` errored because of an invalid argument. FWICT, `product_enablement.bot_management` was [added in 5.13](https://www.fastly.com/documentation/reference/changes/2024/08/terraform-provider-fastly-5.13.0/), but the min version for the fastly terraform provider for this module is 5.10.
* Also, earlier yesterday, the fastly 9.0.0 provider updated and changed the `product_enablement` schema from a boolean to a complex object.

## Related Tickets & Documents
* [CRINGE-239](https://mozilla-hub.atlassian.net/browse/CRINGE-239)
  * Got an error on the `atlantis plan` in mozilla/webservices-infra#10443 .

```
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/fastly_waf/google_fastly_waf/main.tf line 17, in resource "fastly_service_vcl" "default":
│   17:     bot_management     = true
│ 
│ An argument named "bot_management" is not expected here. Did you mean to
│ define a block of type "bot_management"?
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/fastly_waf_antenna/google_fastly_waf/main.tf line 17, in resource "fastly_service_vcl" "default":
│   17:     bot_management     = true
│ 
│ An argument named "bot_management" is not expected here. Did you mean to
│ define a block of type "bot_management"?
╵
```
