### PR TITLE
feat(cloudsql): Allow ignore_change on maintenance version bump

### DIFF
--- a/google_cloudsql_postgres/main.tf
+++ b/google_cloudsql_postgres/main.tf
@@ -147,6 +147,10 @@ resource "google_sql_database_instance" "primary" {
   }
 
   deletion_protection = var.deletion_protection
+
+  lifecycle {
+    ignore_changes = [maintenance_version]
+  }
 }
 
 resource "google_sql_database_instance" "replica" {


### PR DESCRIPTION
…therwise this is treated as a manual change and immediately restarts the DB

## Description

<!--
Please do not leave this blank
This PR Allows ignore_change on maintenance version bump --- otherwise this is treated as a manual change and immediately restarts the DB.
-->

## Related Tickets & Documents
* MZCLD-2586

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
