### PR TITLE
fix(aws_gke_oidc_config): Prevent creating multiple Spacelift OIDC providers

### DIFF
--- a/aws_gke_oidc_config/README.md
+++ b/aws_gke_oidc_config/README.md
@@ -15,10 +15,15 @@ See the `aws_gke_oidc_role` for complete usage instructions
  */
 
 module "oidc_config" {
-  source           = "../."
-  gcp_region       = "us-west1"
-  gcp_project_id   = "moz-fx-platform-mgmt-global"
-  gke_cluster_name = "global-platform-admin-mgmt"
+  source = "../."
+
+  oidc_providers = {
+    mgmt = {
+      gcp_region       = "us-west1"
+      gcp_project_id   = "moz-fx-platform-mgmt-global"
+      gke_cluster_name = "global-platform-admin-mgmt"
+    }
+  }
 }
 ```
 
@@ -26,10 +31,7 @@ module "oidc_config" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_gcp_project_id"></a> [gcp\_project\_id](#input\_gcp\_project\_id) | ID of the GKE cluster's project | `string` | n/a | yes |
-| <a name="input_gcp_region"></a> [gcp\_region](#input\_gcp\_region) | GKE cluster's GCP region | `string` | n/a | yes |
-| <a name="input_gke_cluster_name"></a> [gke\_cluster\_name](#input\_gke\_cluster\_name) | GKE cluster name | `string` | n/a | yes |
-| <a name="input_spacelift_instance"></a> [spacelift\_instance](#input\_spacelift\_instance) | Spacelift instance to establish OIDC trust relationship | `string` | `"mozilla.app.spacelift.io"` | no |
+| <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | Map of GKE clusters and/or Spacelift instances to provision OIDC provider for | <pre>map(object({<br/>    gcp_project_id     = optional(string)<br/>    gcp_region         = optional(string)<br/>    gke_cluster_name   = optional(string)<br/>    spacelift_instance = optional(string)<br/>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/aws_gke_oidc_config/examples/main.tf
+++ b/aws_gke_oidc_config/examples/main.tf
@@ -3,8 +3,13 @@
  */
 
 module "oidc_config" {
-  source           = "../."
-  gcp_region       = "us-west1"
-  gcp_project_id   = "moz-fx-platform-mgmt-global"
-  gke_cluster_name = "global-platform-admin-mgmt"
+  source = "../."
+
+  oidc_providers = {
+    mgmt = {
+      gcp_region       = "us-west1"
+      gcp_project_id   = "moz-fx-platform-mgmt-global"
+      gke_cluster_name = "global-platform-admin-mgmt"
+    }
+  }
 }

--- a/aws_gke_oidc_config/main.tf
+++ b/aws_gke_oidc_config/main.tf
@@ -8,35 +8,31 @@
  * See the `aws_gke_oidc_role` for complete usage instructions
 */
 
-resource "aws_iam_openid_connect_provider" "gke_oidc" {
-  url = "https://container.googleapis.com/v1/projects/${var.gcp_project_id}/locations/${var.gcp_region}/clusters/${var.gke_cluster_name}"
+locals {
+  gke_oidc_providers = { for k, v in var.oidc_providers : k => {
+    client_id_list = ["sts.amazonaws.com"]
+    url            = "https://container.googleapis.com/v1/projects/${v.gcp_project_id}/locations/${v.gcp_region}/clusters/${v.gke_cluster_name}"
+  } if v.gcp_project_id != null && v.gcp_region != null && v.gke_cluster_name != null }
+  spacelift_oidc_providers = { for k, v in var.oidc_providers : k => {
+    client_id_list = [v.spacelift_instance]
+    url            = "https://${v.spacelift_instance}"
+  } if v.spacelift_instance != null }
+}
 
-  client_id_list = [
-    "sts.amazonaws.com"
-  ]
+resource "aws_iam_openid_connect_provider" "oidc_providers" {
+  for_each = merge(local.gke_oidc_providers, local.spacelift_oidc_providers)
+
+  url = each.value.url
+
+  client_id_list = each.value.client_id_list
 
   thumbprint_list = [
-    data.tls_certificate.gke_oidc.certificates.0.sha1_fingerprint
+    data.tls_certificate.oidc_providers[each.key].certificates.0.sha1_fingerprint
   ]
 }
 
-data "tls_certificate" "gke_oidc" {
-  url = "https://container.googleapis.com/v1/projects/${var.gcp_project_id}/locations/${var.gcp_region}/clusters/${var.gke_cluster_name}"
-}
+data "tls_certificate" "oidc_providers" {
+  for_each = merge(local.gke_oidc_providers, local.spacelift_oidc_providers)
 
-
-resource "aws_iam_openid_connect_provider" "spacelift_oidc" {
-  url = "https://${var.spacelift_instance}"
-
-  client_id_list = [
-    var.spacelift_instance
-  ]
-
-  thumbprint_list = [
-    data.tls_certificate.spacelift_oidc.certificates.0.sha1_fingerprint
-  ]
-}
-
-data "tls_certificate" "spacelift_oidc" {
-  url = "https://${var.spacelift_instance}"
+  url = each.value.url
 }

--- a/aws_gke_oidc_config/variables.tf
+++ b/aws_gke_oidc_config/variables.tf
@@ -1,22 +1,20 @@
 ### Required
 
-variable "gcp_region" {
-  description = "GKE cluster's GCP region"
-  type        = string
-}
+variable "oidc_providers" {
+  default     = {}
+  description = "Map of GKE clusters and/or Spacelift instances to provision OIDC provider for"
+  type = map(object({
+    gcp_project_id     = optional(string)
+    gcp_region         = optional(string)
+    gke_cluster_name   = optional(string)
+    spacelift_instance = optional(string)
+  }))
 
-variable "gcp_project_id" {
-  description = "ID of the GKE cluster's project"
-  type        = string
-}
-
-variable "gke_cluster_name" {
-  description = "GKE cluster name"
-  type        = string
-}
-
-variable "spacelift_instance" {
-  description = "Spacelift instance to establish OIDC trust relationship"
-  default     = "mozilla.app.spacelift.io"
-  type        = string
+  validation {
+    condition = alltrue([for k, v in var.oidc_providers :
+      (v.gcp_project_id != null && v.gcp_region != null && v.gke_cluster_name != null && v.spacelift_instance == null)
+      || (v.gcp_project_id == null && v.gcp_region == null && v.gke_cluster_name == null && v.spacelift_instance != null)
+    ])
+    error_message = "You must set all variables for GKE clusters (gcp_project_id, gcp_region, and gke_cluster_name) or Spacelift instances (spacelift_instance)"
+  }
 }


### PR DESCRIPTION
## Description
This PR prevents creating multiple Spacelift OIDC providers by allowing consumers to specify n GKE clusters or spacelift instances. Found after I merged #456 😓 

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* MZCLD-2672
* #456 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
