### PR TITLE
feat(versions): convert pins to pessimistic

### DIFF
--- a/aws_gcp_vpn/versions.tf
+++ b/aws_gcp_vpn/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.37"
+      version = "~> 6.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.41"
+      version = "~> 7.0"
     }
   }
 }

--- a/aws_gke_oidc_config/versions.tf
+++ b/aws_gke_oidc_config/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.37"
+      version = "~> 6.0"
     }
   }
-  required_version = "~> 1.0"
 }

--- a/aws_gke_oidc_role/versions.tf
+++ b/aws_gke_oidc_role/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.37"
+      version = "~> 6.0"
     }
   }
-  required_version = "~> 1.0"
 }

--- a/aws_itse-roles/versions.tf
+++ b/aws_itse-roles/versions.tf
@@ -1,12 +1,8 @@
 terraform {
   required_providers {
-
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = "~> 6.0"
     }
-
   }
-
-  required_version = ">= 1.0"
 }

--- a/google_bigquery_log_sink/versions.tf
+++ b/google_bigquery_log_sink/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0"
+      version = "~> 7.0"
     }
   }
-  required_version = ">= 1.0"
 }

--- a/google_bigquery_syndicated_dataset/README.md
+++ b/google_bigquery_syndicated_dataset/README.md
@@ -49,14 +49,13 @@ module "treeherder" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 7.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/google_bigquery_syndicated_dataset/versions.tf
+++ b/google_bigquery_syndicated_dataset/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0"
+      version = "~> 7.0"
     }
   }
-  required_version = ">= 1.0"
 }

--- a/google_cdn-external/versions.tf
+++ b/google_cdn-external/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.42"
+      version = "~> 7.0"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/google_cdn_backend_bucket/versions.tf
+++ b/google_cdn_backend_bucket/versions.tf
@@ -1,10 +1,8 @@
 terraform {
-  required_version = ">= 1.8.3"
-
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.32.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/google_certificate_manager_certificate_map/versions.tf
+++ b/google_certificate_manager_certificate_map/versions.tf
@@ -1,15 +1,13 @@
 terraform {
-  required_version = ">= 1.8.3"
-
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.6.2"
+      version = "~> 3.0"
     }
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.32.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/google_cloudsql_mysql/versions.tf
+++ b/google_cloudsql_mysql/versions.tf
@@ -1,10 +1,8 @@
 terraform {
-  required_version = ">= 1.0"
-
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.2.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/google_cloudsql_postgres/versions.tf
+++ b/google_cloudsql_postgres/versions.tf
@@ -1,10 +1,8 @@
 terraform {
-  required_version = ">= 1.0"
-
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.2.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/google_datastream/versions.tf
+++ b/google_datastream/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.71"
+      version = "~> 7.0"
     }
   }
-  required_version = ">= 1.0"
 }

--- a/google_deployment_accounts/versions.tf
+++ b/google_deployment_accounts/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.0"
+      version = "~> 7.0"
     }
   }
-  required_version = "~> 1.0"
 }

--- a/google_fastly_waf/versions.tf
+++ b/google_fastly_waf/versions.tf
@@ -1,5 +1,4 @@
 terraform {
-  required_version = ">= 1.8"
   required_providers {
     fastly = {
       source  = "fastly/fastly"
@@ -7,11 +6,11 @@ terraform {
     }
     sigsci = {
       source  = "signalsciences/sigsci"
-      version = ">= 3.0.0"
+      version = "~> 3.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/google_gar/versions.tf
+++ b/google_gar/versions.tf
@@ -2,12 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.0"
+      version = "~> 7.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0"
+      version = "~> 7.0"
     }
   }
-  required_version = "~> 1.0"
 }

--- a/google_gke/versions.tf
+++ b/google_gke/versions.tf
@@ -1,16 +1,13 @@
 terraform {
-
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.11"
+      version = "~> 7.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.11"
+      version = "~> 7.0"
     }
   }
-
-  required_version = ">= 1.8"
 }

--- a/google_gke_namespace_logging/versions.tf
+++ b/google_gke_namespace_logging/versions.tf
@@ -2,12 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.0"
+      version = "~> 7.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0"
+      version = "~> 7.0"
     }
   }
-  required_version = "~> 1.0"
 }

--- a/google_gke_tenant/versions.tf
+++ b/google_gke_tenant/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.0"
+      version = "~> 7.0"
     }
   }
-  required_version = "~> 1.0"
 }

--- a/google_memcache/versions.tf
+++ b/google_memcache/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0"
+      version = "~> 7.0"
     }
   }
-  required_version = "~> 1.0"
 }

--- a/google_monitoring/versions.tf
+++ b/google_monitoring/versions.tf
@@ -1,10 +1,8 @@
 terraform {
-  required_version = ">= 1.8.3"
-
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.32.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/google_permissions/versions.tf
+++ b/google_permissions/versions.tf
@@ -2,12 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">=6.7.0"
+      version = "~> 7.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">=6.7.0"
+      version = "~> 7.0"
     }
   }
-  required_version = "~> 1.2"
 }

--- a/google_project-dns/versions.tf
+++ b/google_project-dns/versions.tf
@@ -1,11 +1,8 @@
 terraform {
   required_providers {
-
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.0"
+      version = "~> 7.0"
     }
   }
-
-  required_version = ">= 1.0"
 }

--- a/google_project/versions.tf
+++ b/google_project/versions.tf
@@ -1,15 +1,12 @@
 terraform {
   required_providers {
-
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.0"
+      version = "~> 7.0"
     }
-
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
-
-  required_version = ">= 1.0"
 }

--- a/google_psc_to_elastic/versions.tf
+++ b/google_psc_to_elastic/versions.tf
@@ -2,12 +2,11 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = ">= 0.9.0"
+      version = "~> 0.12"
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.27"
+      version = "~> 7.0"
     }
   }
-  required_version = ">= 1.0"
 }

--- a/google_redis/versions.tf
+++ b/google_redis/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0"
+      version = "~> 7.0"
     }
   }
-  required_version = "~> 1.0"
 }

--- a/google_tfstate/versions.tf
+++ b/google_tfstate/versions.tf
@@ -1,11 +1,8 @@
 terraform {
   required_providers {
-
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.0"
+      version = "~> 7.0"
     }
   }
-
-  required_version = ">= 1.0"
 }

--- a/google_workload_identity/versions.tf
+++ b/google_workload_identity/versions.tf
@@ -1,11 +1,8 @@
 terraform {
   required_providers {
-
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0"
+      version = "~> 7.0"
     }
   }
-
-  required_version = ">= 1.0"
 }

--- a/mozilla_access_event_consumer/versions.tf
+++ b/mozilla_access_event_consumer/versions.tf
@@ -1,13 +1,12 @@
 terraform {
-  required_version = ">= 1.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = "~> 7.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = ">= 2.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/mozilla_workgroup/versions.tf
+++ b/mozilla_workgroup/versions.tf
@@ -1,11 +1,8 @@
 terraform {
   required_providers {
-
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.0"
+      version = "~> 7.0"
     }
   }
-
-  required_version = ">= 1.0"
 }

--- a/pagerduy_service/versions.tf
+++ b/pagerduy_service/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
-      version = "~> 3.30.1"
+      version = "~> 3.30"
     }
   }
 }

--- a/pagerduy_team/versions.tf
+++ b/pagerduy_team/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
-      version = "~> 3.30.1"
+      version = "~> 3.30"
     }
   }
 }


### PR DESCRIPTION
## Description
Convert all optimistic module pins to instead be pessimistic pins on the current latest major version.This is to prevent surprise breakages (as described in [the ticket](https://mozilla-hub.atlassian.net/browse/MZCLD-2611)) when new major versions are published.

This _shouldn_'t break any existing modules since the optimistic pins were already auto-upgrading everything to latest. 

Also gets rid of `required_version` since Terraform versions are managed by Atlantis & Spacelift (and also by the module consumers in the infra repos).

## Related Tickets & Documents
* MZCLD-2611
