### PR TITLE
feat(fastly_waf): add ddos_protection variable

### DIFF
--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -18,6 +18,10 @@ resource "fastly_service_vcl" "default" {
       enabled      = true
       contentguard = "off"
     }
+    ddos_protection {
+      enabled = var.ddos_protection != null ? var.ddos_protection.enabled : false
+      mode    = var.ddos_protection != null ? var.ddos_protection.mode : "off"
+    }
   }
 
   gzip {

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -117,6 +117,19 @@ variable "cache_header" {
   description = "A cache header to check to toggle cache lookup"
 }
 
+variable "ddos_protection" {
+  description = "Optional DDoS Protection configuration for the Fastly service product enablement."
+  type = object({
+    enabled = bool
+    mode    = string
+  })
+  default = null
+  validation {
+    condition     = var.ddos_protection == null || contains(["off", "log", "block"], var.ddos_protection.mode)
+    error_message = "ddos_protection.mode must be one of: off, log, or block."
+  }
+}
+
 ## NGWAF
 variable "ngwaf_agent_level" {
   type        = string


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

Add the `ddos_protection` variable to be able to enable Fastly DDoS protection features. Default is disabled.

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/INFRASEC-2923

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
