### PR TITLE
feat(fastly_waf): allow bot management as variable

### DIFF
--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -15,8 +15,8 @@ resource "fastly_service_vcl" "default" {
   product_enablement {
     brotli_compression = true
     bot_management {
-      enabled      = true
-      contentguard = "off"
+      enabled      = var.bot_management != null ? var.bot_management.enabled : true
+      contentguard = var.bot_management != null ? var.bot_management.contentguard : "off"
     }
     ddos_protection {
       enabled = var.ddos_protection != null ? var.ddos_protection.enabled : false

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -117,6 +117,19 @@ variable "cache_header" {
   description = "A cache header to check to toggle cache lookup"
 }
 
+variable "bot_management" {
+  description = "Bot Management configuration for the Fastly service product enablement."
+  type = object({
+    enabled      = bool
+    contentguard = string
+  })
+  default = null
+  validation {
+    condition     = var.bot_management == null || contains(["off", "on"], var.bot_management.contentguard)
+    error_message = "bot_management.contentguard must be either off or on."
+  }
+}
+
 variable "ddos_protection" {
   description = "Optional DDoS Protection configuration for the Fastly service product enablement."
   type = object({


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

Allow bot management to be passed as a variable. Default is enabled but with `contentguard` off.

## Related Tickets & Documents
* [INFRASEC-2923](https://mozilla-hub.atlassian.net/browse/INFRASEC-2923)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
