### PR TITLE
fix(google_gke): ignore ephemeral_storage_local_ssd_config drift

### DIFF
--- a/google_gke/cluster.tf
+++ b/google_gke/cluster.tf
@@ -342,6 +342,11 @@ resource "google_container_node_pool" "pools" {
       initial_node_count,
       node_config[0].oauth_scopes,
       node_config[0].metadata,
+      # GKE auto-attaches local NVMe SSDs to certain GPU machine types
+      # (e.g., a3-highgpu-2g). The module does not model this attribute,
+      # so let the provider keep whatever GKE configures rather than
+      # repeatedly trying to remove it (which forces pool replacement).
+      node_config[0].ephemeral_storage_local_ssd_config,
     ]
   }
 }


### PR DESCRIPTION
## Description

GKE auto-attaches local NVMe SSDs to certain GPU machine types (notably `a3-highgpu-2g`, which physically include onboard NVMe). The `google_gke` module doesn't model `node_config[0].ephemeral_storage_local_ssd_config` as a configurable attribute, so every plan against a cluster with such a pool reads `local_ssd_count` from live state and computes a diff against the unset config value, marking the pool as `forces replacement`.

Concrete impact: in `dataservices-high/tf/nonprod`, the `gpu-a3-highgpu-2g` pool (introduced in [global-platform-admin#6069](https://github.com/mozilla/global-platform-admin/pull/6069)) plans `4 -> null`, `forces replacement` on every PR touching that directory. The plan output ([example from another PR](https://github.com/mozilla/global-platform-admin/pull/6157#issuecomment-4347084676)) is noisy and the apply fails on the create step of `create_before_destroy` because the new and old pools share the same name (no `name_prefix` is used by this module):

```
Error: resource - .../nodePools/gpu-a3-highgpu-2g - already exists
```

This blocks unrelated changes (e.g. adding a new tenant node pool) on plan/apply churn for the GPU pool.

## Fix

Add `node_config[0].ephemeral_storage_local_ssd_config` to the `lifecycle.ignore_changes` list of `google_container_node_pool.pools`. The provider keeps whatever value GKE configured at pool creation, the diff disappears, and replacement no longer triggers.

The SSD count for these GPU machines is essentially a property of the instance type rather than a tenant decision, so suppression is the right shape. If a future caller wants explicit control, exposing a configurable variable is a separate, additive change.

## Validation
https://github.com/mozilla/global-platform-admin/pull/6157#issuecomment-4347489966

## Related Tickets & Documents
* SVCSE-4435
* SVCSE-4429
* SVCSE-4142