### PR TITLE
feat(fast_waf): allow disable brotli compression

### DIFF
--- a/google_fastly_waf/README.md
+++ b/google_fastly_waf/README.md
@@ -141,20 +141,25 @@ module "fastly_stage" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_application"></a> [application](#input\_application) | Application name | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment this module is deployed into | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project\_ id for BigQuery logging | `string` | n/a | yes |
+| <a name="input_realm"></a> [realm](#input\_realm) | The realm this module is deployed into | `string` | n/a | yes |
 | <a name="input_backends"></a> [backends](#input\_backends) | A list of backends | `list(any)` | `[]` | no |
+| <a name="input_bot_management"></a> [bot\_management](#input\_bot\_management) | Bot Management configuration for the Fastly service product enablement. | <pre>object({<br/>    enabled      = bool<br/>    contentguard = string<br/>  })</pre> | `null` | no |
+| <a name="input_brotli_compression"></a> [brotli\_compression](#input\_brotli\_compression) | Enable brotli compression or not | `bool` | `true` | no |
 | <a name="input_cache_header"></a> [cache\_header](#input\_cache\_header) | A cache header to check to toggle cache lookup | `string` | `""` | no |
 | <a name="input_cache_settings"></a> [cache\_settings](#input\_cache\_settings) | List of cache settings for the Fastly service. | <pre>list(object({<br/>    name            = string<br/>    action          = optional(string)<br/>    cache_condition = optional(string)<br/>    stale_ttl       = optional(number)<br/>    ttl             = optional(number)<br/>  }))</pre> | `[]` | no |
 | <a name="input_conditions"></a> [conditions](#input\_conditions) | List of Fastly conditions to create (REQUEST, RESPONSE or CACHE). | <pre>list(object({<br/>    name      = string           # required, unique<br/>    statement = string           # VCL conditional expression<br/>    type      = string           # one of: REQUEST, RESPONSE, CACHE<br/>    priority  = optional(number) # lower runs first, default 10<br/>  }))</pre> | `[]` | no |
+| <a name="input_ddos_protection"></a> [ddos\_protection](#input\_ddos\_protection) | Optional DDoS Protection configuration for the Fastly service product enablement. | <pre>object({<br/>    enabled = bool<br/>    mode    = string<br/>  })</pre> | `null` | no |
 | <a name="input_domains"></a> [domains](#input\_domains) | A list of domains | `list(any)` | `[]` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | The environment this module is deployed into | `string` | n/a | yes |
 | <a name="input_https_redirect_enabled"></a> [https\_redirect\_enabled](#input\_https\_redirect\_enabled) | n/a | `bool` | `true` | no |
 | <a name="input_log_sampling_enabled"></a> [log\_sampling\_enabled](#input\_log\_sampling\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_log_sampling_percent"></a> [log\_sampling\_percent](#input\_log\_sampling\_percent) | n/a | `string` | `"10"` | no |
 | <a name="input_ngwaf_agent_level"></a> [ngwaf\_agent\_level](#input\_ngwaf\_agent\_level) | This is the site wide blocking level | `string` | `"log"` | no |
+| <a name="input_ngwaf_attack_thresholds"></a> [ngwaf\_attack\_thresholds](#input\_ngwaf\_attack\_thresholds) | Attack threshold configurations applied when ngwaf\_baseline\_protection is enabled. | <pre>list(object({<br/>    interval  = number<br/>    threshold = number<br/>  }))</pre> | <pre>[<br/>  {<br/>    "interval": 1,<br/>    "threshold": 10<br/>  },<br/>  {<br/>    "interval": 10,<br/>    "threshold": 100<br/>  },<br/>  {<br/>    "interval": 60,<br/>    "threshold": 600<br/>  }<br/>]</pre> | no |
+| <a name="input_ngwaf_baseline_protection"></a> [ngwaf\_baseline\_protection](#input\_ngwaf\_baseline\_protection) | When true, disables immediate blocking and enables baseline attack threshold alerts. | `bool` | `false` | no |
 | <a name="input_ngwaf_immediate_block"></a> [ngwaf\_immediate\_block](#input\_ngwaf\_immediate\_block) | n/a | `bool` | `true` | no |
 | <a name="input_ngwaf_percent_enabled"></a> [ngwaf\_percent\_enabled](#input\_ngwaf\_percent\_enabled) | n/a | `number` | `100` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project\_ id for BigQuery logging | `string` | n/a | yes |
-| <a name="input_realm"></a> [realm](#input\_realm) | The realm this module is deployed into | `string` | n/a | yes |
 | <a name="input_response_objects"></a> [response\_objects](#input\_response\_objects) | List of synthetic response objects to attach to the Fastly service. | <pre>list(object({<br/>    name              = string           # required<br/>    status            = optional(number) # e.g. 503<br/>    response          = optional(string) # e.g. "Ok"<br/>    content           = optional(string)<br/>    content_type      = optional(string)<br/>    request_condition = optional(string) # name of an existing REQUEST condition<br/>    cache_condition   = optional(string) # name of an existing CACHE   condition<br/>  }))</pre> | `[]` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | n/a | `string` | `null` | no |
 | <a name="input_snippets"></a> [snippets](#input\_snippets) | snippets | `list(any)` | `[]` | no |

--- a/google_fastly_waf/README.md
+++ b/google_fastly_waf/README.md
@@ -10,7 +10,6 @@ module "fastly" {
   project_id  = bar
   realm       = bar
 
-  waf_enabled       = true
   ngwaf_agent_level = "block"
 
   subscription_domains = [
@@ -39,7 +38,6 @@ module "fastly_maintenance_page" {
   project_id  = bar
   realm       = bar
 
-  waf_enabled       = true
   ngwaf_agent_level = "block"
 
   subscription_domains = [
@@ -111,7 +109,6 @@ module "fastly_stage" {
   project_id  = bar
   realm       = bar
 
-  waf_enabled       = true
   ngwaf_agent_level = "block"
   stage             = true
 

--- a/google_fastly_waf/examples/example.tf
+++ b/google_fastly_waf/examples/example.tf
@@ -5,7 +5,6 @@ module "fastly" {
   project_id  = bar
   realm       = bar
 
-  waf_enabled       = true
   ngwaf_agent_level = "block"
 
   subscription_domains = [

--- a/google_fastly_waf/examples/example_maintenance_page.tf
+++ b/google_fastly_waf/examples/example_maintenance_page.tf
@@ -5,7 +5,6 @@ module "fastly_maintenance_page" {
   project_id  = bar
   realm       = bar
 
-  waf_enabled       = true
   ngwaf_agent_level = "block"
 
   subscription_domains = [

--- a/google_fastly_waf/examples/example_stage.tf
+++ b/google_fastly_waf/examples/example_stage.tf
@@ -12,7 +12,6 @@ module "fastly_stage" {
   project_id  = bar
   realm       = bar
 
-  waf_enabled       = true
   ngwaf_agent_level = "block"
   stage             = true
 

--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -13,7 +13,7 @@ resource "fastly_service_vcl" "default" {
   stage    = var.stage
 
   product_enablement {
-    brotli_compression = true
+    brotli_compression = var.brotli_compression
     bot_management {
       enabled      = var.bot_management != null ? var.bot_management.enabled : true
       contentguard = var.bot_management != null ? var.bot_management.contentguard : "off"

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -188,3 +188,9 @@ variable "ngwaf_attack_thresholds" {
     error_message = "ngwaf_attack_thresholds must contain exactly 3 entries (one each for the 1, 10, and 60 minute intervals)."
   }
 }
+
+variable "brotli_compression" {
+  type        = bool
+  default     = true
+  description = "Enable brotli compression or not"
+}


### PR DESCRIPTION
## Description

Fastly automatically normalizes the value of the `Accept-Encoding` header on inbound requests. When Brotli compression is enabled and the `Accept-Encoding` header contains `br`, which is the case for most modern clients, Fastly rewrites the entire header value to `br`.

In some cases, this behavior is undesirable. For example:

* The origin may not support Brotli compression, such as the Treeherder Django application.
* The origin may be backed by GCS buckets, which perform decompressive transcoding automatically when `Accept-Encoding` is not `gzip` and the stored object has `Content-Encoding: gzip`.

In these scenarios, disabling Brotli compression is preferable because it prevents Fastly from normalizing the `Accept-Encoding` header to `br`, even when the client supports it.

## Related Tickets & Documents
* [Fastly Accpet-Encoding Normalization](https://www.fastly.com/documentation/reference/http/http-headers/Accept-Encoding/#normalization)
* [GCS Decompressive Transcoding](https://docs.cloud.google.com/storage/docs/transcoding#decompressive_transcoding)
* https://mozilla-hub.atlassian.net/browse/MZCLD-2949
* https://mozilla-hub.atlassian.net/browse/MZCLD-1234
