### PR TITLE
chore(google_bigquery_syndicated_dataset): avoid permadiffs

### DIFF
--- a/google_bigquery_syndicated_dataset/variables.tf
+++ b/google_bigquery_syndicated_dataset/variables.tf
@@ -80,6 +80,17 @@ variable "access" {
   }))
   description = "Application-specific access blocks for this dataset. projectOwners OWNER access is included by default unless disable_project_owners_access is set."
   default     = []
+
+  validation {
+    condition = alltrue([
+      for a in var.access : !contains([
+        "roles/bigquery.dataOwner",
+        "roles/bigquery.dataEditor",
+        "roles/bigquery.dataViewer",
+      ], coalesce(a.role, ""))
+    ])
+    error_message = "Use the BigQuery-specific dataset roles OWNER/WRITER/READER instead of roles/bigquery.dataOwner|dataEditor|dataViewer to avoid permadiffs. See https://docs.cloud.google.com/bigquery/docs/access-control-basic-roles#dataset-basic-roles. Custom roles are still allowed."
+  }
 }
 
 variable "disable_project_owners_access" {


### PR DESCRIPTION
## Description

Addresses https://github.com/mozilla/global-platform-admin/pull/6256#discussion_r3236521319 by disallowing standard role usage. This is a no-op against all usage of the module but will guide future users toward the correct configuration.

## Related Tickets & Documents
* RELOPS-2330
* SVCSE-2997

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
