### PR TITLE
feat(tf): implement new versioning scheme; update readme

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -136,13 +136,13 @@ jobs:
         persist-credentials: false
       # Do the per-module steps in a composite action because matrixes can't handle dynamic outputs
     - name: Version bump
-      uses: mozilla/terraform-modules/.github/actions/versions@e5fc38a939be3df68dca237d2b4ed4d535addd59
+      uses: mozilla/terraform-modules/.github/actions/versions@22e5e067f6867f361158c21ad3034fa2aa28576c
       with:
         package-name: ${{ matrix.directory }}
         release-type: ${{ needs.detect.outputs.release-type }}
     - name: Generate docs
       if: needs.detect.outputs.is-merge-event == 'false' && needs.detect.outputs.release-type != 'no-release'
-      uses: mozilla/terraform-modules/.github/actions/docs@e5fc38a939be3df68dca237d2b4ed4d535addd59
+      uses: mozilla/terraform-modules/.github/actions/docs@22e5e067f6867f361158c21ad3034fa2aa28576c
       with:
         package-name: ${{ matrix.directory }}
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository also uses [GitHub Actions](.github/workflows/ci.yaml) to run sta
   * the module subdirectory name follows the format `provider_name`;
   * a `README.md` exists (use terraform-docs, detailed below, to generate);
   * a `main.tf` file exists;
-  * a `versions.tf` file exists & contains value `terraform.required_version`;
+  * a `versions.tf` file exists
 * security checks are run, including validating providers used are allowed & secrets scanning (via same pre-commit tooling).
 
 ### Versioning and Releases
@@ -27,6 +27,10 @@ If your PR contains [Conventional commits](https://www.conventionalcommits.org/e
 
 Release changelogs are generated based off of the contents of your PR description.
 Readmes will be automatically generated, using `.terraform-docs.yml` from the module directory (if it exists).
+
+#### Provider Versions
+
+See https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/2606923830/Tofu+Terraform+Versioning+Strategy for guidance on provider versioning.
 
 ## Creating modules
 
@@ -67,16 +71,17 @@ Some examples on using modules in this repository follow.
 }
 ```
 
-Using the (imaginary) `google_gke-cluster` module with always the latest version (e.g. following main branch):
-```terraform
- module "gke" {
-  source      = "git@github.com:mozilla/terraform-modules.git//google_gke-cluster?ref=main"
-}
-```
-
 Using the (imaginary) `google_gke-cluster` module based on a specific (imaginary) git commit:
 ```terraform
  module "gke" {
   source      = "git@github.com:mozilla/terraform-modules.git//google_gke-cluster?ref=69ad17030bfa4ea46f68f8cc449102d446658851"
+}
+```
+
+**Do not pin to main**: pinning to main makes your infrastructure non-deterministic, this will soon be disallowed by CI
+Using the (imaginary) `google_gke-cluster` module with always the latest version (** Not recommended**):
+```terraform
+ module "gke" {
+  source      = "git@github.com:mozilla/terraform-modules.git//google_gke-cluster?ref=main"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Using the (imaginary) `google_gke-cluster` module based on a specific (imaginary
 }
 ```
 
-**Do not pin to main**: pinning to main makes your infrastructure non-deterministic, this will soon be disallowed by CI
+**Do not pin to main**: pinning to main makes your infrastructure non-deterministic, this will soon be disallowed by CI.
 Using the (imaginary) `google_gke-cluster` module with always the latest version (**Not recommended**):
 ```terraform
  module "gke" {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Using the (imaginary) `google_gke-cluster` module based on a specific (imaginary
 ```
 
 **Do not pin to main**: pinning to main makes your infrastructure non-deterministic, this will soon be disallowed by CI
-Using the (imaginary) `google_gke-cluster` module with always the latest version (** Not recommended**):
+Using the (imaginary) `google_gke-cluster` module with always the latest version (**Not recommended**):
 ```terraform
  module "gke" {
   source      = "git@github.com:mozilla/terraform-modules.git//google_gke-cluster?ref=main"

--- a/aws_gcp_vpn/versions.tf
+++ b/aws_gcp_vpn/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "> 5.0, < 7.0"
+      version = ">= 5.0, < 7.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/aws_gcp_vpn/versions.tf
+++ b/aws_gcp_vpn/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "> 5.0, < 7.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/aws_gke_oidc_config/versions.tf
+++ b/aws_gke_oidc_config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "> 5.0, < 7.0"
     }
   }
 }

--- a/aws_gke_oidc_config/versions.tf
+++ b/aws_gke_oidc_config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "> 5.0, < 7.0"
+      version = ">= 5.0, < 7.0"
     }
   }
 }

--- a/aws_gke_oidc_role/versions.tf
+++ b/aws_gke_oidc_role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "> 5.0, < 7.0"
     }
   }
 }

--- a/aws_gke_oidc_role/versions.tf
+++ b/aws_gke_oidc_role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "> 5.0, < 7.0"
+      version = ">= 5.0, < 7.0"
     }
   }
 }

--- a/aws_itse-roles/versions.tf
+++ b/aws_itse-roles/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "> 5.0, < 7.0"
     }
   }
 }

--- a/aws_itse-roles/versions.tf
+++ b/aws_itse-roles/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "> 5.0, < 7.0"
+      version = ">= 5.0, < 7.0"
     }
   }
 }

--- a/google_bigquery_log_sink/versions.tf
+++ b/google_bigquery_log_sink/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_bigquery_log_sink/versions.tf
+++ b/google_bigquery_log_sink/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_bigquery_syndicated_dataset/README.md
+++ b/google_bigquery_syndicated_dataset/README.md
@@ -49,13 +49,13 @@ module "treeherder" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_google"></a> [google](#requirement\_google) | > 6.0, < 8.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0, < 8.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | > 6.0, < 8.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0, < 8.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/google_bigquery_syndicated_dataset/README.md
+++ b/google_bigquery_syndicated_dataset/README.md
@@ -49,13 +49,13 @@ module "treeherder" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | > 6.0, < 8.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 7.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | > 6.0, < 8.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/google_bigquery_syndicated_dataset/versions.tf
+++ b/google_bigquery_syndicated_dataset/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_bigquery_syndicated_dataset/versions.tf
+++ b/google_bigquery_syndicated_dataset/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_cdn-external/versions.tf
+++ b/google_cdn-external/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_cdn-external/versions.tf
+++ b/google_cdn-external/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_cdn_backend_bucket/versions.tf
+++ b/google_cdn_backend_bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_cdn_backend_bucket/versions.tf
+++ b/google_cdn_backend_bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_certificate_manager_certificate_map/versions.tf
+++ b/google_certificate_manager_certificate_map/versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "> 2.0, < 4.0"
+      version = ">= 2.0, < 4.0"
     }
 
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_certificate_manager_certificate_map/versions.tf
+++ b/google_certificate_manager_certificate_map/versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"
+      version = "> 2.0, < 4.0"
     }
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_cloudsql_mysql/versions.tf
+++ b/google_cloudsql_mysql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_cloudsql_mysql/versions.tf
+++ b/google_cloudsql_mysql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_cloudsql_postgres/versions.tf
+++ b/google_cloudsql_postgres/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_cloudsql_postgres/versions.tf
+++ b/google_cloudsql_postgres/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_datastream/versions.tf
+++ b/google_datastream/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_datastream/versions.tf
+++ b/google_datastream/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_deployment_accounts/versions.tf
+++ b/google_deployment_accounts/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_deployment_accounts/versions.tf
+++ b/google_deployment_accounts/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_fastly_waf/versions.tf
+++ b/google_fastly_waf/versions.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = "~> 9.0"
+      version = "> 8.0, < 10.0"
     }
     sigsci = {
       source  = "signalsciences/sigsci"
-      version = "~> 3.0"
+      version = "> 2.0, < 4.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_fastly_waf/versions.tf
+++ b/google_fastly_waf/versions.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = "> 8.0, < 10.0"
+      version = ">= 8.0, < 10.0"
     }
     sigsci = {
       source  = "signalsciences/sigsci"
-      version = "> 2.0, < 4.0"
+      version = ">= 2.0, < 4.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_gar/versions.tf
+++ b/google_gar/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_gar/versions.tf
+++ b/google_gar/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_gke/versions.tf
+++ b/google_gke/versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_gke/versions.tf
+++ b/google_gke/versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_gke_namespace_logging/versions.tf
+++ b/google_gke_namespace_logging/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_gke_namespace_logging/versions.tf
+++ b/google_gke_namespace_logging/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_gke_tenant/versions.tf
+++ b/google_gke_tenant/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_gke_tenant/versions.tf
+++ b/google_gke_tenant/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_memcache/versions.tf
+++ b/google_memcache/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_memcache/versions.tf
+++ b/google_memcache/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_monitoring/versions.tf
+++ b/google_monitoring/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_monitoring/versions.tf
+++ b/google_monitoring/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_permissions/examples/entitlement_basic/versions.tf
+++ b/google_permissions/examples/entitlement_basic/versions.tf
@@ -1,11 +1,9 @@
 terraform {
-  required_version = ">= 1.0"
-
   required_providers {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.12"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_permissions/versions.tf
+++ b/google_permissions/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_permissions/versions.tf
+++ b/google_permissions/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_project/versions.tf
+++ b/google_project/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "> 2.0, < 4.0"
+      version = ">= 2.0, < 4.0"
     }
   }
 }

--- a/google_project/versions.tf
+++ b/google_project/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"
+      version = "> 2.0, < 4.0"
     }
   }
 }

--- a/google_project_dns/versions.tf
+++ b/google_project_dns/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_project_dns/versions.tf
+++ b/google_project_dns/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_psc_to_elastic/versions.tf
+++ b/google_psc_to_elastic/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "~> 0.12"
+      version = "> 0.11, < 0.13"
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_psc_to_elastic/versions.tf
+++ b/google_psc_to_elastic/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "> 0.11, < 0.13"
+      version = ">= 0.11, < 0.13"
     }
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_redis/versions.tf
+++ b/google_redis/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_redis/versions.tf
+++ b/google_redis/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_tfstate/versions.tf
+++ b/google_tfstate/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_tfstate/versions.tf
+++ b/google_tfstate/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/google_workload_identity/versions.tf
+++ b/google_workload_identity/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/google_workload_identity/versions.tf
+++ b/google_workload_identity/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/mozilla_access_event_consumer/versions.tf
+++ b/mozilla_access_event_consumer/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = "> 1.0, < 3.0"
     }
   }
 }

--- a/mozilla_access_event_consumer/versions.tf
+++ b/mozilla_access_event_consumer/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "> 1.0, < 3.0"
+      version = ">= 1.0, < 3.0"
     }
   }
 }

--- a/mozilla_workgroup/versions.tf
+++ b/mozilla_workgroup/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "> 6.0, < 8.0"
     }
   }
 }

--- a/mozilla_workgroup/versions.tf
+++ b/mozilla_workgroup/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 6.0, < 8.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/pagerduty_service/versions.tf
+++ b/pagerduty_service/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
-      version = "~> 3.30"
+      version = "> 3.29, < 3.31"
     }
   }
 }

--- a/pagerduty_service/versions.tf
+++ b/pagerduty_service/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
-      version = "> 3.29, < 3.31"
+      version = ">= 3.0, < 4.0"
     }
   }
 }

--- a/pagerduty_team/versions.tf
+++ b/pagerduty_team/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
-      version = "~> 3.30"
+      version = "> 3.29, < 3.31"
     }
   }
 }

--- a/pagerduty_team/versions.tf
+++ b/pagerduty_team/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
-      version = "> 3.29, < 3.31"
+      version = ">= 3.0, < 4.0"
     }
   }
 }


### PR DESCRIPTION
## Description
- Converts all pessimistic pins into equivalent bracketed pins to match new versioning strategy (https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/2606923830/Tofu+Terraform+Versioning+Strategy).
- Updates readme to reflect changes
- Bump to latest composite action version to pull in `google_project` fix (https://github.com/mozilla/terraform-modules/commit/22e5e067f6867f361158c21ad3034fa2aa28576c)

## Related Tickets & Documents
* MZCLD-696