### PR TITLE
fix(ci): fix tag regex to not conflate similarly named modules

### DIFF
--- a/.github/actions/versions/action.yml
+++ b/.github/actions/versions/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: bash
       run: |
         git fetch --tags
-        TAG=$(git tag -l "$PACKAGE_NAME-*" --sort=-v:refname | head -n 1)
+        TAG=$(git tag -l "$PACKAGE_NAME-[0-9]*" --sort=-v:refname | head -n 1)
 
         if [ -z "$TAG" ] ; then
           echo "No git tag found for $PACKAGE_NAME, using 0.0.0 as previous version"


### PR DESCRIPTION
## Description
With https://github.com/mozilla/terraform-modules/pull/470 `google_project_dns` is now named correctly, but the old tag is still causing CI problems for `google_project`

This PR updates the tag regex to strictly require a number after the hyphen, which prevents the CI for `google_project` from picking up `google_project-dns` tags.

## Related Tickets & Documents
* MZCLD-696
* Failing CI: https://github.com/mozilla/terraform-modules/actions/runs/25884482029/job/76072502328?pr=469