### PR TITLE
fix(google_bigquery_syndicated_dataset): use output for dataset_id

### DIFF
--- a/google_bigquery_syndicated_dataset/outputs.tf
+++ b/google_bigquery_syndicated_dataset/outputs.tf
@@ -1,6 +1,6 @@
 output "dataset_id" {
   description = "The dataset ID."
-  value       = var.dataset_id
+  value       = var.create_dataset ? google_bigquery_dataset.dataset[0].dataset_id : var.dataset_id
 }
 
 output "id" {


### PR DESCRIPTION
## Description

@quiiver caught this in local testing of https://github.com/mozilla/global-platform-admin/pull/6289. By using the output downstream tables that rely on the output of this module should be less likely to hit API timing issues.

This is a no-op change otherwise.

## Related Tickets & Documents
* MZCLD-2654

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
