### PR TITLE
fix(versions): rm last main pins; fix examples

### DIFF
--- a/google_bigquery_syndicated_dataset/.terraform-docs.yml
+++ b/google_bigquery_syndicated_dataset/.terraform-docs.yml
@@ -5,7 +5,7 @@ content: |-
 
   ```hcl
   module "treeherder" {
-    source = "github.com/mozilla/terraform-modules//google_bigquery_syndicated_dataset?ref=main"
+    source = "github.com/mozilla/terraform-modules//google_bigquery_syndicated_dataset?ref=google_bigquery_syndicated_dataset-1.3.1"
 
     dataset_id            = "for_treeherder_1"
     syndicated_dataset_id = "treeherder_db"

--- a/google_bigquery_syndicated_dataset/README.md
+++ b/google_bigquery_syndicated_dataset/README.md
@@ -30,7 +30,7 @@ detection automation will make these manual steps unnecessary.
 
 ```hcl
 module "treeherder" {
-  source = "github.com/mozilla/terraform-modules//google_bigquery_syndicated_dataset?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_bigquery_syndicated_dataset?ref=google_bigquery_syndicated_dataset-1.3.1"
 
   dataset_id            = "for_treeherder_1"
   syndicated_dataset_id = "treeherder_db"
@@ -62,7 +62,7 @@ module "treeherder" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_syndication_workgroup"></a> [syndication\_workgroup](#module\_syndication\_workgroup) | github.com/mozilla/terraform-modules//mozilla_workgroup | main |
+| <a name="module_syndication_workgroup"></a> [syndication\_workgroup](#module\_syndication\_workgroup) | github.com/mozilla/terraform-modules//mozilla_workgroup | mozilla_workgroup-1.3.0 |
 
 ## Resources
 

--- a/google_bigquery_syndicated_dataset/main.tf
+++ b/google_bigquery_syndicated_dataset/main.tf
@@ -98,7 +98,7 @@ data "terraform_remote_state" "org" {
 # Service accounts that perform syndication
 # Currently Jenkins with plans to move to Airflow, see https://mozilla-hub.atlassian.net/browse/SVCSE-3005
 module "syndication_workgroup" {
-  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=mozilla_workgroup-1.3.0"
   ids    = var.syndication_workgroup_ids
 }
 

--- a/google_datastream/examples/postgres_to_bq.tf
+++ b/google_datastream/examples/postgres_to_bq.tf
@@ -1,5 +1,5 @@
 module "datastream" {
-  source = "github.com/mozilla/terraform-modules//google_datastream?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_datastream?ref=google_datastream-0.3.0"
 
   application = var.application
   environment = var.environment

--- a/google_gar/README.md
+++ b/google_gar/README.md
@@ -6,7 +6,7 @@ Creates a GAR repository and a service account to access it.
 
 ```hcl
 module "gar" {
-  source = "github.com/mozilla/terraform-modules//google_gar?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gar?ref=google_gar-0.4.0"
 
   description        = "Default repository for test project"
   application        = "glonk"

--- a/google_gar/examples/example.tf
+++ b/google_gar/examples/example.tf
@@ -1,5 +1,5 @@
 module "gar" {
-  source = "github.com/mozilla/terraform-modules//google_gar?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gar?ref=google_gar-0.4.0"
 
   description        = "Default repository for test project"
   application        = "glonk"

--- a/google_gke/README.md
+++ b/google_gke/README.md
@@ -242,7 +242,7 @@ data "terraform_remote_state" "vpc" {
 }
 
 module "gke" {
-  source = "github.com/mozilla/terraform-modules//google_gke?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gke?ref=google_gke-0.11.0"
 
   name       = "my-cluster"
   project_id = "shared-clusters"
@@ -284,7 +284,7 @@ data "terraform_remote_state" "vpc" {
 }
 
 module "gke" {
-  source = "github.com/mozilla/terraform-modules//google_gke?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gke?ref=google_gke-0.11.0"
 
   name               = "my-cluster"
   project_id         = "shared-clusters"
@@ -328,7 +328,7 @@ data "terraform_remote_state" "vpc" {
 }
 
 module "gke" {
-  source = "github.com/mozilla/terraform-modules//google_gke?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gke?ref=google_gke-0.11.0"
 
   name               = "my-cluster"
   project_id         = "shared-clusters"

--- a/google_gke/examples/complex1.tf
+++ b/google_gke/examples/complex1.tf
@@ -8,7 +8,7 @@ data "terraform_remote_state" "vpc" {
 }
 
 module "gke" {
-  source = "github.com/mozilla/terraform-modules//google_gke?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gke?ref=google_gke-0.11.0"
 
   name               = "my-cluster"
   project_id         = "shared-clusters"

--- a/google_gke/examples/complex2.tf
+++ b/google_gke/examples/complex2.tf
@@ -8,7 +8,7 @@ data "terraform_remote_state" "vpc" {
 }
 
 module "gke" {
-  source = "github.com/mozilla/terraform-modules//google_gke?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gke?ref=google_gke-0.11.0"
 
   name               = "my-cluster"
   project_id         = "shared-clusters"

--- a/google_gke/examples/simple.tf
+++ b/google_gke/examples/simple.tf
@@ -8,7 +8,7 @@ data "terraform_remote_state" "vpc" {
 }
 
 module "gke" {
-  source = "github.com/mozilla/terraform-modules//google_gke?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gke?ref=google_gke-0.11.0"
 
   name       = "my-cluster"
   project_id = "shared-clusters"

--- a/google_gke_namespace_logging/README.md
+++ b/google_gke_namespace_logging/README.md
@@ -7,7 +7,7 @@ The log routing configuration happens as part of the GKE tenant bootstrapping.
 ## Example
 ```hcl
 module "gke_logging" {
-  source = "github.com/mozilla/terraform-modules//google_gke_namespace_logging?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gke_namespace_logging?ref=google_gke_namespace_logging-1.3.0"
 
   application                           = "glonk"
   realm                                 = "dev"

--- a/google_gke_namespace_logging/examples/example1.tf
+++ b/google_gke_namespace_logging/examples/example1.tf
@@ -1,5 +1,5 @@
 module "gke_logging" {
-  source = "github.com/mozilla/terraform-modules//google_gke_namespace_logging?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_gke_namespace_logging?ref=google_gke_namespace_logging-1.3.0"
 
   application                           = "glonk"
   realm                                 = "dev"

--- a/google_memcache/README.md
+++ b/google_memcache/README.md
@@ -12,7 +12,7 @@ locals {
 }
 
 module "memcache" {
-  source = "github.com/mozilla/terraform-modules//google_memcache?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_memcache?ref=google_memcache-0.3.0"
 
   application        = local.name
   environment        = "dev"

--- a/google_memcache/examples/example1.tf
+++ b/google_memcache/examples/example1.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "memcache" {
-  source = "github.com/mozilla/terraform-modules//google_memcache?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_memcache?ref=google_memcache-0.3.0"
 
   application        = local.name
   environment        = "dev"

--- a/google_permissions/README.md
+++ b/google_permissions/README.md
@@ -9,7 +9,7 @@ For information on how to add new roles to the modules, please see [this documen
 
 ```hcl
 module "permissions" {
-  source = "github.com/mozilla/terraform-modules//google_permissions?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_permissions?ref=google_permissions-0.9.0"
   // it is assumed that you loaded and have available a local.project
   google_folder_id          = local.project.folder.id
   google_prod_project_id    = local.project["prod"].id

--- a/google_permissions/examples/basic/main.tf
+++ b/google_permissions/examples/basic/main.tf
@@ -1,5 +1,5 @@
 module "permissions" {
-  source = "github.com/mozilla/terraform-modules//google_permissions?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_permissions?ref=google_permissions-0.9.0"
   // it is assumed that you loaded and have available a local.project
   google_folder_id          = local.project.folder.id
   google_prod_project_id    = local.project["prod"].id

--- a/google_permissions/workgroups.tf
+++ b/google_permissions/workgroups.tf
@@ -1,14 +1,14 @@
 module "admins_workgroup" {
-  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=mozilla_workgroup-1.3.0"
   ids    = var.admin_ids
 }
 
 module "developers_workgroup" {
-  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=mozilla_workgroup-1.3.0"
   ids    = var.developer_ids
 }
 
 module "viewers_workgroup" {
-  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=mozilla_workgroup-1.3.0"
   ids    = var.viewer_ids
 }

--- a/google_redis/README.md
+++ b/google_redis/README.md
@@ -12,7 +12,7 @@ locals {
 }
 
 module "redis" {
-  source = "github.com/mozilla/terraform-modules//google_redis?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_redis?ref=google_redis-0.4.0"
 
   application    = local.name
   environment    = "dev"

--- a/google_redis/examples/example1.tf
+++ b/google_redis/examples/example1.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "redis" {
-  source = "github.com/mozilla/terraform-modules//google_redis?ref=main"
+  source = "github.com/mozilla/terraform-modules//google_redis?ref=google_redis-0.4.0"
 
   application    = local.name
   environment    = "dev"

--- a/mozilla_access_event_consumer/README.md
+++ b/mozilla_access_event_consumer/README.md
@@ -82,7 +82,7 @@ locals {
 
 module "access_consumer" {
   # Use the latest version of this module from https://github.com/mozilla/terraform-modules/tags
-  source = "github.com/mozilla/terraform-modules//mozilla_access_event_consumer?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_access_event_consumer?ref=mozilla_access_event_consumer-1.3.0"
 
   project_id  = local.project_id
   application = local.application
@@ -163,7 +163,7 @@ Create a Pub/Sub subscription for pull-based processing from GKE:
 
 module "access_consumer" {
   # Use the latest version of this module from https://github.com/mozilla/terraform-modules/tags
-  source = "github.com/mozilla/terraform-modules//mozilla_access_event_consumer?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_access_event_consumer?ref=mozilla_access_event_consumer-1.3.0"
 
   project_id            = local.project_id
   application           = local.application

--- a/mozilla_access_event_consumer/examples/cloudfunction/main.tf
+++ b/mozilla_access_event_consumer/examples/cloudfunction/main.tf
@@ -9,7 +9,7 @@ locals {
 
 module "access_consumer" {
   # Use the latest version of this module from https://github.com/mozilla/terraform-modules/tags
-  source = "github.com/mozilla/terraform-modules//mozilla_access_event_consumer?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_access_event_consumer?ref=mozilla_access_event_consumer-1.3.0"
 
   project_id  = local.project_id
   application = local.application

--- a/mozilla_access_event_consumer/examples/gke/main.tf
+++ b/mozilla_access_event_consumer/examples/gke/main.tf
@@ -5,7 +5,7 @@
 
 module "access_consumer" {
   # Use the latest version of this module from https://github.com/mozilla/terraform-modules/tags
-  source = "github.com/mozilla/terraform-modules//mozilla_access_event_consumer?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_access_event_consumer?ref=mozilla_access_event_consumer-1.3.0"
 
   project_id            = local.project_id
   application           = local.application

--- a/mozilla_workgroup/README.md
+++ b/mozilla_workgroup/README.md
@@ -23,7 +23,7 @@ This module is cloned from https://github.com/mozilla-services/cloudops-infra-te
 ## Example
 ```hcl
 module "workgroup" {
-  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=mozilla_workgroup-1.3.0"
 
   ids                           = ["workgroup:app/admins"]
   roles                         = {}

--- a/mozilla_workgroup/examples/example1.tf
+++ b/mozilla_workgroup/examples/example1.tf
@@ -1,5 +1,5 @@
 module "workgroup" {
-  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=main"
+  source = "github.com/mozilla/terraform-modules//mozilla_workgroup?ref=mozilla_workgroup-1.3.0"
 
   ids                           = ["workgroup:app/admins"]
   roles                         = {}

--- a/pagerduty_team/examples/example.tf
+++ b/pagerduty_team/examples/example.tf
@@ -9,7 +9,7 @@ data "pagerduty_user" "team_users" {
 }
 
 module "pagerduty_team" {
-  source = "github.com/mozilla/terraform-modules//pagerduty_team?ref=main"
+  source = "github.com/mozilla/terraform-modules//pagerduty_team?ref=pagerduy_team-0.2.0"
 
   team_name = "foo"
 


### PR DESCRIPTION
## Description
Removes last remaining `main` pins in `google_bigquery_syndicated_dataset` & `google_permissions` to comply with our [versioning strategy](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/2606923830/Tofu+Terraform+Versioning+Strategy).

Also replaces all main pins in examples.

## Related Tickets & Documents
* MZCLD-2019
