### PR TITLE
feat(fastly): Allow setting a client cert and key

### DIFF
--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -98,6 +98,13 @@ resource "fastly_service_vcl" "default" {
       # don't fail early, "terraform apply" will fail when it calls Fastly API.
       ssl_check_cert    = lookup(backend.value, "use_ssl", false) ? true : false
       ssl_cert_hostname = lookup(backend.value, "use_ssl", false) ? backend.value.ssl_cert_hostname : ""
+
+      # Optional client certificate for mutual TLS to the origin. When set,
+      # Fastly presents this cert/key during the origin TLS handshake (used for
+      # origins that enforce client mTLS, e.g. the shared GKE Gateway). Both must
+      # be PEM. Omit for non-mTLS origins.
+      ssl_client_cert = lookup(backend.value, "ssl_client_cert", null)
+      ssl_client_key  = lookup(backend.value, "ssl_client_key", null)
     }
   }
 

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -1,5 +1,11 @@
 variable "backends" {
-  description = "A list of backends"
+  description = <<-EOT
+    A list of backends. Common keys: name, address, port, use_ssl,
+    ssl_cert_hostname, ssl_sni_hostname, override_host. Optional mutual-TLS keys
+    ssl_client_cert / ssl_client_key (both PEM) make Fastly present a client
+    certificate during the origin TLS handshake, for origins that enforce client
+    mTLS (e.g. the shared GKE Gateway); omit them for non-mTLS origins.
+  EOT
   type        = list(any)
   default     = []
 }


### PR DESCRIPTION
## Description

Allow setting a client certificate and key for communicating via mTLS