### PR TITLE
fix(pagerduty_*): Correct issues in example module source references

### DIFF
--- a/pagerduty_service/examples/example.tf
+++ b/pagerduty_service/examples/example.tf
@@ -1,6 +1,6 @@
 
 module "pagerduty_service" {
-  source                  = "github.com/mozilla/terraform-modules//pagerduty_service?ref=main"
+  source                  = "github.com/mozilla/terraform-modules//pagerduty_service?ref=pagerduty_service-0.2.0"
   name                    = "foo"
   application_name        = "bar"
   description             = "glab"

--- a/pagerduty_team/examples/example.tf
+++ b/pagerduty_team/examples/example.tf
@@ -9,7 +9,7 @@ data "pagerduty_user" "team_users" {
 }
 
 module "pagerduty_team" {
-  source = "github.com/mozilla/terraform-modules//pagerduty_team?ref=pagerduy_team-0.2.0"
+  source = "github.com/mozilla/terraform-modules//pagerduty_team?ref=pagerduty_team-0.2.0"
 
   team_name = "foo"
 


### PR DESCRIPTION
## Description
Fixes a typo and references a version tag instead of `main`.

## Related Tickets & Documents
N/A