### PR TITLE
feat(fastly): allow additional log fields

### DIFF
--- a/google_fastly_waf/README.md
+++ b/google_fastly_waf/README.md
@@ -5,19 +5,19 @@
 ```hcl
 module "fastly" {
   source      = "github.com/mozilla/terraform-modules//google_fastly_waf?ref=main"
-  application = glab
-  environment = foo
+  application = my-app
+  environment = stage
   project_id  = bar
-  realm       = bar
+  realm       = dev
 
-  ngwaf_agent_level = "block"
+  ngwaf_agent_level = "logs"
 
   subscription_domains = [
     { name = "my-app.mozilla.org" }
   ]
 
   domains = [
-    { name = "my-cool-app.global.ssl.fastly.net" },
+    { name = "my-app.global.ssl.fastly.net" },
   ]
 
   backends = [
@@ -150,9 +150,9 @@ module "fastly_stage" {
 | <a name="input_ddos_protection"></a> [ddos\_protection](#input\_ddos\_protection) | Optional DDoS Protection configuration for the Fastly service product enablement. | <pre>object({<br/>    enabled = bool<br/>    mode    = string<br/>  })</pre> | `null` | no |
 | <a name="input_ddos_protection_alert"></a> [ddos\_protection\_alert](#input\_ddos\_protection\_alert) | Optional Slack alerting for Fastly DDoS Protection. When set, the module creates a Slack `fastly_integration` and a `fastly_alert` on the `ddos_protection_requests_detect_count` stats metric that notifies the channel behind the webhook. Intended to be paired with `ddos_protection` being enabled. Set to `null` (the default) to create no alerting resources. | <pre>object({<br/>    enabled              = optional(bool, true)<br/>    slack_webhook_secret = string<br/>    threshold            = optional(number, 1)<br/>    period               = optional(string, "5m")<br/>    description          = optional(string)<br/>  })</pre> | `null` | no |
 | <a name="input_domains"></a> [domains](#input\_domains) | A list of domains | `list(any)` | `[]` | no |
+| <a name="input_extra_log_fields"></a> [extra\_log\_fields](#input\_extra\_log\_fields) | Extra columns to add to the BigQuery logs table, on top of the base schema in logging/bq\_schema.json. Each entry adds both the log-format field and the matching table column, so the two cannot drift. `expression` is a bare Fastly VCL expression -- no `%{}V` wrapper and no `%%` escaping. The module always wraps it in `json.escape()` and always emits a quoted `STRING` / `NULLABLE` column, so a value should never break the JSON log line. Nesting works, e.g. `if(req.http.X-Foo, req.http.X-Foo, "none")`. There is no type knob: cast in SQL if you need a number (the base schema already stores `response\_status` as `STRING`). Append-only. BigQuery cannot reorder or drop columns, so add new entries at the end of the list and never remove one -- to retire a field, stop populating it and leave the column. This writes into the shared WAF log dataset, which is retained for 90 days and broadly readable. Never log credentials, cookies, authorization headers, or request bodies. | <pre>list(object({<br/>    name        = string<br/>    expression  = string<br/>    description = optional(string, "")<br/>  }))</pre> | `[]` | no |
 | <a name="input_https_redirect_enabled"></a> [https\_redirect\_enabled](#input\_https\_redirect\_enabled) | n/a | `bool` | `true` | no |
 | <a name="input_legacy_edge_deployment"></a> [legacy\_edge\_deployment](#input\_legacy\_edge\_deployment) | If true (default), deploy NGWAF via the legacy sigsci EdgeDeployment APIs and Fastly dynamic snippets. If false, deploy via Fastly's product\_enablement ngwaf block. Default preserves behavior for services still on the legacy method. | `bool` | `true` | no |
-| <a name="input_log_response_content_encoding"></a> [log\_response\_content\_encoding](#input\_log\_response\_content\_encoding) | When true, adds a `response_content_encoding` column to the BigQuery logs table, populated from the response `Content-Encoding` header. Useful for measuring compression negotiation (`gzip`, `br`, and Compression Dictionary Transport's `dcb`/`dcz`). Off by default so the shared log schema only grows for services that need it. | `bool` | `false` | no |
 | <a name="input_log_sampling_enabled"></a> [log\_sampling\_enabled](#input\_log\_sampling\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_log_sampling_percent"></a> [log\_sampling\_percent](#input\_log\_sampling\_percent) | n/a | `string` | `"10"` | no |
 | <a name="input_ngwaf_agent_level"></a> [ngwaf\_agent\_level](#input\_ngwaf\_agent\_level) | This is the site wide blocking level | `string` | `"log"` | no |

--- a/google_fastly_waf/README.md
+++ b/google_fastly_waf/README.md
@@ -152,6 +152,7 @@ module "fastly_stage" {
 | <a name="input_domains"></a> [domains](#input\_domains) | A list of domains | `list(any)` | `[]` | no |
 | <a name="input_https_redirect_enabled"></a> [https\_redirect\_enabled](#input\_https\_redirect\_enabled) | n/a | `bool` | `true` | no |
 | <a name="input_legacy_edge_deployment"></a> [legacy\_edge\_deployment](#input\_legacy\_edge\_deployment) | If true (default), deploy NGWAF via the legacy sigsci EdgeDeployment APIs and Fastly dynamic snippets. If false, deploy via Fastly's product\_enablement ngwaf block. Default preserves behavior for services still on the legacy method. | `bool` | `true` | no |
+| <a name="input_log_response_content_encoding"></a> [log\_response\_content\_encoding](#input\_log\_response\_content\_encoding) | When true, adds a `response_content_encoding` column to the BigQuery logs table, populated from the response `Content-Encoding` header. Useful for measuring compression negotiation (`gzip`, `br`, and Compression Dictionary Transport's `dcb`/`dcz`). Off by default so the shared log schema only grows for services that need it. | `bool` | `false` | no |
 | <a name="input_log_sampling_enabled"></a> [log\_sampling\_enabled](#input\_log\_sampling\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_log_sampling_percent"></a> [log\_sampling\_percent](#input\_log\_sampling\_percent) | n/a | `string` | `"10"` | no |
 | <a name="input_ngwaf_agent_level"></a> [ngwaf\_agent\_level](#input\_ngwaf\_agent\_level) | This is the site wide blocking level | `string` | `"log"` | no |

--- a/google_fastly_waf/bigquery.tf
+++ b/google_fastly_waf/bigquery.tf
@@ -50,16 +50,26 @@ resource "google_bigquery_table" "fastly" {
   }
 
   # The base schema lives in logging/bq_schema.json alongside the log formats it mirrors.
-  # Optional columns are appended here, gated on the same variable that adds the matching
-  # field to the log format in locals.tf. The two must stay in sync: a field present in the
-  # format but missing from the schema will make BigQuery reject the insert and drop the log line.
+  # Extra columns come from var.extra_log_fields, which also drives the matching log-format
+  # fields in locals.tf, so the two cannot drift: a field present in the format but missing from
+  # the schema would make BigQuery reject the insert and drop the whole log line.
   schema = jsonencode(concat(
-    jsondecode(file("${path.module}/logging/bq_schema.json")),
-    var.log_response_content_encoding ? [{
-      name        = "response_content_encoding"
+    local.base_bq_schema,
+    [for f in var.extra_log_fields : {
+      name        = f.name
       type        = "STRING"
       mode        = "NULLABLE"
-      description = "Content-Encoding negotiated for the response (e.g. gzip, br, dcb, dcz)"
-    }] : [],
+      description = f.description
+    }],
   ))
+
+  lifecycle {
+    precondition {
+      condition = length(setintersection(
+        toset([for c in local.base_bq_schema : c.name]),
+        toset([for f in var.extra_log_fields : f.name]),
+      )) == 0
+      error_message = "extra_log_fields names must not duplicate a base column in logging/bq_schema.json."
+    }
+  }
 }

--- a/google_fastly_waf/bigquery.tf
+++ b/google_fastly_waf/bigquery.tf
@@ -49,143 +49,17 @@ resource "google_bigquery_table" "fastly" {
     component_code = "fastly-logs"
   }
 
-  schema = <<EOF
-[
-  {
-    "name": "timestamp",
-    "type": "TIMESTAMP",
-    "mode": "NULLABLE",
-    "description": "The timestamp"
-  },
-  {
-    "name": "response_state",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "State of Response"
-  },
-  {
-    "name": "response_status",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Status of Response"
-  },
-  {
-    "name": "response_reason",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Response reason"
-  },
-  {
-    "name": "request_referer",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Referrer Information"
-  },
-  {
-    "name": "request_method",
-    "type": "STRING",
-    "mode": "NULLABLE"
-  },
-  {
-    "name": "request_protocol",
-    "type": "STRING",
-    "mode": "NULLABLE"
-  },
-  {
-    "name": "request_user_agent",
-    "type": "STRING",
-    "mode": "NULLABLE"
-  },
-  {
-    "name": "url",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "URL"
-  },
-  {
-    "name": "waf_executed",
-    "type": "BOOLEAN",
-    "mode": "NULLABLE",
-    "description": "Waf Executed"
-  },
-  {
-    "name": "ngwaf_agentresponse",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Response of Agent"
-  },
-  {
-    "name": "ngwaf_decision_ms",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Decision in MS"
-  },
-  {
-    "name": "ngwaf_signals",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Signals"
-  },
-  {
-    "name": "response_bytes_written",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Size of body written to request"
-  },
-  {
-    "name": "ja3",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "ja3 of client"
-  },
-  {
-    "name": "ja4",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "ja4 of client"
-  },
-  {
-    "name": "request_client_ip",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "client IP"
-  },
-  {
-    "name": "h2fp",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "HTTP/2 implementation details"
-  },
-  {
-    "name": "asn",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Autonomous System Number"
-  },
-  {
-    "name": "ohfp",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "order and structure of HTTP headers"
-  },
-  {
-    "name": "proxy_type",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "proxy type"
-  },
-  {
-    "name": "proxy_desc",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "proxy description"
-  },
-  {
-    "name": "fastly_request_id",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Fastly Request ID"
-  }
-]
-EOF
+  # The base schema lives in logging/bq_schema.json alongside the log formats it mirrors.
+  # Optional columns are appended here, gated on the same variable that adds the matching
+  # field to the log format in locals.tf. The two must stay in sync: a field present in the
+  # format but missing from the schema will make BigQuery reject the insert and drop the log line.
+  schema = jsonencode(concat(
+    jsondecode(file("${path.module}/logging/bq_schema.json")),
+    var.log_response_content_encoding ? [{
+      name        = "response_content_encoding"
+      type        = "STRING"
+      mode        = "NULLABLE"
+      description = "Content-Encoding negotiated for the response (e.g. gzip, br, dcb, dcz)"
+    }] : [],
+  ))
 }

--- a/google_fastly_waf/examples/example.tf
+++ b/google_fastly_waf/examples/example.tf
@@ -7,6 +7,17 @@ module "fastly" {
 
   ngwaf_agent_level = "block"
 
+  # Extra BigQuery log columns, on top of the module's base schema. `expression` is a bare
+  # Fastly VCL expression; the module json.escape()s it and adds a STRING column of the same
+  # name. Append-only -- BigQuery cannot reorder or drop columns.
+  extra_log_fields = [
+    {
+      name        = "response_content_encoding"
+      expression  = "resp.http.Content-Encoding"
+      description = "Content-Encoding negotiated for the response (e.g. gzip, br, dcb, dcz)"
+    },
+  ]
+
   subscription_domains = [
     { name = "my-app.mozilla.org" }
   ]

--- a/google_fastly_waf/locals.tf
+++ b/google_fastly_waf/locals.tf
@@ -8,4 +8,17 @@ locals {
   # The waf_bypass_snippet relies on the legacy x-sigsci-no-inspection header,
   # which is only honored by the legacy EdgeDeployment integration.
   snippets = var.legacy_edge_deployment ? concat(var.snippets, var.stage ? [local.waf_bypass_snippet] : []) : var.snippets
+
+  # Base BigQuery log format
+  bq_log_format_base = trimspace(trimsuffix(
+    trimspace(file("${path.module}/logging/${var.legacy_edge_deployment ? "bq_format.txt" : "bq_format_v2.txt"}")),
+    "}"
+  ))
+
+  # Opt-in response_content_encoding log field
+  optional_bq_log_fields = compact([
+    var.log_response_content_encoding ? "\"response_content_encoding\":\"%%{json.escape(resp.http.Content-Encoding)}V\"" : "",
+  ])
+
+  bq_log_format = "${join(", ", concat([local.bq_log_format_base], local.optional_bq_log_fields))} }"
 }

--- a/google_fastly_waf/locals.tf
+++ b/google_fastly_waf/locals.tf
@@ -9,16 +9,23 @@ locals {
   # which is only honored by the legacy EdgeDeployment integration.
   snippets = var.legacy_edge_deployment ? concat(var.snippets, var.stage ? [local.waf_bypass_snippet] : []) : var.snippets
 
-  # Base BigQuery log format
-  bq_log_format_base = trimspace(trimsuffix(
-    trimspace(file("${path.module}/logging/${var.legacy_edge_deployment ? "bq_format.txt" : "bq_format_v2.txt"}")),
-    "}"
-  ))
+  # Base BigQuery log format, used verbatim unless extra fields are configured.
+  bq_log_format_file = file("${path.module}/logging/${var.legacy_edge_deployment ? "bq_format.txt" : "bq_format_v2.txt"}")
 
-  # Opt-in response_content_encoding log field
-  optional_bq_log_fields = compact([
-    var.log_response_content_encoding ? "\"response_content_encoding\":\"%%{json.escape(resp.http.Content-Encoding)}V\"" : "",
-  ])
+  # Base BigQuery table schema, mirroring the log format above.
+  base_bq_schema = jsondecode(file("${path.module}/logging/bq_schema.json"))
 
-  bq_log_format = "${join(", ", concat([local.bq_log_format_base], local.optional_bq_log_fields))} }"
+  # Caller-supplied extra columns. The expression is always wrapped in json.escape() and always
+  # quoted, so a value can never break the JSON log line -- BigQuery rejects a malformed line by
+  # dropping the whole row, which would otherwise let a request suppress its own WAF log entry.
+  extra_bq_log_fields = [
+    for f in var.extra_log_fields :
+    "\"${f.name}\":\"%%{json.escape(${f.expression})}V\""
+  ]
+
+  # Services that set no extra fields get the file byte-for-byte.
+  bq_log_format = length(var.extra_log_fields) == 0 ? local.bq_log_format_file : "${join(", ", concat(
+    [trimspace(trimsuffix(trimspace(local.bq_log_format_file), "}"))],
+    local.extra_bq_log_fields,
+  ))} }"
 }

--- a/google_fastly_waf/locals.tf
+++ b/google_fastly_waf/locals.tf
@@ -23,9 +23,10 @@ locals {
     "\"${f.name}\":\"%%{json.escape(${f.expression})}V\""
   ]
 
-  # Services that set no extra fields get the file byte-for-byte.
+  # Services that set no extra fields get the file byte-for-byte. The extended form keeps the
+  # file's trailing newline too.
   bq_log_format = length(var.extra_log_fields) == 0 ? local.bq_log_format_file : "${join(", ", concat(
     [trimspace(trimsuffix(trimspace(local.bq_log_format_file), "}"))],
     local.extra_bq_log_fields,
-  ))} }"
+  ))} }\n"
 }

--- a/google_fastly_waf/logging/bq_schema.json
+++ b/google_fastly_waf/logging/bq_schema.json
@@ -1,0 +1,137 @@
+[
+  {
+    "name": "timestamp",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE",
+    "description": "The timestamp"
+  },
+  {
+    "name": "response_state",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "State of Response"
+  },
+  {
+    "name": "response_status",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Status of Response"
+  },
+  {
+    "name": "response_reason",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Response reason"
+  },
+  {
+    "name": "request_referer",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Referrer Information"
+  },
+  {
+    "name": "request_method",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "request_protocol",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "request_user_agent",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "URL"
+  },
+  {
+    "name": "waf_executed",
+    "type": "BOOLEAN",
+    "mode": "NULLABLE",
+    "description": "Waf Executed"
+  },
+  {
+    "name": "ngwaf_agentresponse",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Response of Agent"
+  },
+  {
+    "name": "ngwaf_decision_ms",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Decision in MS"
+  },
+  {
+    "name": "ngwaf_signals",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Signals"
+  },
+  {
+    "name": "response_bytes_written",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Size of body written to request"
+  },
+  {
+    "name": "ja3",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "ja3 of client"
+  },
+  {
+    "name": "ja4",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "ja4 of client"
+  },
+  {
+    "name": "request_client_ip",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "client IP"
+  },
+  {
+    "name": "h2fp",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "HTTP/2 implementation details"
+  },
+  {
+    "name": "asn",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Autonomous System Number"
+  },
+  {
+    "name": "ohfp",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "order and structure of HTTP headers"
+  },
+  {
+    "name": "proxy_type",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "proxy type"
+  },
+  {
+    "name": "proxy_desc",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "proxy description"
+  },
+  {
+    "name": "fastly_request_id",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Fastly Request ID"
+  }
+]

--- a/google_fastly_waf/main.tf
+++ b/google_fastly_waf/main.tf
@@ -257,7 +257,7 @@ resource "fastly_service_vcl" "default" {
     project_id         = var.project_id
     table              = google_bigquery_table.fastly.table_id
     account_name       = google_service_account.log_uploader.account_id
-    format             = file("${path.module}/logging/${var.legacy_edge_deployment ? "bq_format.txt" : "bq_format_v2.txt"}")
+    format             = local.bq_log_format
     response_condition = var.log_sampling_enabled ? local.log_sample_name : ""
   }
 

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -112,6 +112,17 @@ variable "log_sampling_enabled" {
   default = false
 }
 
+variable "log_response_content_encoding" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    When true, adds a `response_content_encoding` column to the BigQuery logs table, populated
+    from the response `Content-Encoding` header. Useful for measuring compression negotiation
+    (`gzip`, `br`, and Compression Dictionary Transport's `dcb`/`dcz`). Off by default so the
+    shared log schema only grows for services that need it.
+  EOT
+}
+
 variable "https_redirect_enabled" {
   type    = bool
   default = true

--- a/google_fastly_waf/variables.tf
+++ b/google_fastly_waf/variables.tf
@@ -112,15 +112,44 @@ variable "log_sampling_enabled" {
   default = false
 }
 
-variable "log_response_content_encoding" {
-  type        = bool
-  default     = false
+variable "extra_log_fields" {
+  type = list(object({
+    name        = string
+    expression  = string
+    description = optional(string, "")
+  }))
+  default     = []
   description = <<-EOT
-    When true, adds a `response_content_encoding` column to the BigQuery logs table, populated
-    from the response `Content-Encoding` header. Useful for measuring compression negotiation
-    (`gzip`, `br`, and Compression Dictionary Transport's `dcb`/`dcz`). Off by default so the
-    shared log schema only grows for services that need it.
+    Extra columns to add to the BigQuery logs table, on top of the base schema in
+    logging/bq_schema.json. Each entry adds both the log-format field and the matching table
+    column, so the two cannot drift.
+
+    `expression` is a bare Fastly VCL expression -- no `%%{}V` wrapper and no `%%` escaping. The
+    module always wraps it in `json.escape()` and always emits a quoted `STRING` / `NULLABLE`
+    column, so a value can never break the JSON log line. Nesting works, e.g.
+    `if(req.http.X-Foo, req.http.X-Foo, "none")`. There is no type knob: cast in SQL if you need
+    a number (the base schema already stores `response_status` as `STRING`).
+
+    Append-only. BigQuery cannot reorder or drop columns, so add new entries at the end of the
+    list and never remove one -- to retire a field, stop populating it and leave the column.
+
+    Never log credentials, cookies, authorization headers, or request bodies.
   EOT
+
+  validation {
+    condition     = alltrue([for f in var.extra_log_fields : can(regex("^[a-z_][a-z0-9_]*$", f.name))])
+    error_message = "Each extra_log_fields name must be a valid BigQuery column name matching ^[a-z_][a-z0-9_]*$."
+  }
+
+  validation {
+    condition     = length(distinct([for f in var.extra_log_fields : f.name])) == length(var.extra_log_fields)
+    error_message = "Each extra_log_fields name must be unique."
+  }
+
+  validation {
+    condition     = alltrue([for f in var.extra_log_fields : trimspace(f.expression) != ""])
+    error_message = "Each extra_log_fields expression must be a non-empty Fastly VCL expression."
+  }
 }
 
 variable "https_redirect_enabled" {


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

In order to implement [feat(fastly): Log response `Content-Encoding` into BigQuery by leplatrem · Pull Request #487 · mozilla/terraform-modules](https://github.com/mozilla/terraform-modules/pull/487), we need to: 
- rework how `bigquery.tf` builds the schema to allow a conditional column.
- add a new variable to pass the value to insert

## Related Tickets & Documents
* [INFRASEC-3668](https://mozilla-hub.atlassian.net/browse/INFRASEC-3668)
* Tested [here](https://github.com/mozilla/sandbox-infra/pull/1125)
  * No changed planned when no variable: https://github.com/mozilla/sandbox-infra/pull/1125#issuecomment-5371209381 
  * changes look good when variable is set: https://github.com/mozilla/sandbox-infra/pull/1125#issuecomment-5371907277 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
