### PR TITLE
fix(pagerduty_service): Fix perma-diff when setting timeouts to 0

### DIFF
--- a/pagerduty_service/main.tf
+++ b/pagerduty_service/main.tf
@@ -1,8 +1,12 @@
 resource "pagerduty_service" "service" {
-  name                    = var.name
-  description             = var.description
-  auto_resolve_timeout    = var.auto_resolve_timeout
-  acknowledgement_timeout = var.acknowledgement_timeout
+  name        = var.name
+  description = var.description
+  # You thought that 0 is a pretty sensible developer interface to disable a timeout right?
+  # But what if you were a some kind of chaos lover and decided "The string 'null' is better"?
+  # Well then you'd be the Pagerduty Terraform developers ;(
+  # https://github.com/PagerDuty/terraform-provider-pagerduty/blob/960ed279bba2b96608bd04e9abedc140c98e782b/pagerduty/resource_pagerduty_service.go#L381-L399
+  auto_resolve_timeout    = var.auto_resolve_timeout == 0 ? "null" : var.auto_resolve_timeout
+  acknowledgement_timeout = var.acknowledgement_timeout == 0 ? "null" : var.auto_resolve_timeout
 
   escalation_policy = local.escalation_policy_id
   alert_creation    = "create_alerts_and_incidents"


### PR DESCRIPTION
## Description
While our [module docs say](https://github.com/mozilla/terraform-modules/tree/main/pagerduty_service#inputs) “0 disables timeout” the Terraform provider docs say “Disabled if set to the "null" string.”

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* MZCLD-3894

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
